### PR TITLE
Fixing Out-RsFolderContent and Write-RsFolderContent 

### DIFF
--- a/Functions/CatalogItems/Out-RsFolderContent.ps1
+++ b/Functions/CatalogItems/Out-RsFolderContent.ps1
@@ -74,7 +74,11 @@ function Out-RsFolderContent
     {
         if(($item.TypeName -eq 'Folder') -and $Recurse)
         {
-            $relativePath = Clear-Substring -string $item.Path -substring $Path -position front
+            $relativePath = $item.Path
+            if($Path -ne "/")
+            {
+                $relativePath = Clear-Substring -string $relativePath -substring $Path -position front
+            }
             $relativePath = $relativePath.Replace("/", "\")
             
             $newFolder = $Destination + $relativePath
@@ -88,8 +92,12 @@ function Out-RsFolderContent
            $item.TypeName -eq "DataSet")
         {
             # We're relying on the fact that the implementation of Get-RsCatalogItems will show us the folder before their content, 
-            # when using the -recurse option, so we can assume that any subfolder will be created before we download the items it contains 
-            $relativePath = Clear-Substring -string $item.Path -substring $Path -position front
+            # when using the -recurse option, so we can assume that any subfolder will be created before we download the items it contains
+            $relativePath = $item.Path
+            if($Path -ne "/")
+            {
+                $relativePath = Clear-Substring -string $relativePath -substring $Path -position front
+            }
             $relativePath = Clear-Substring -string $relativePath -substring ("/" + $item.Name) -position back
             $relativePath = $relativePath.replace("/", "\")
 

--- a/Functions/CatalogItems/Write-RsFolderContent.ps1
+++ b/Functions/CatalogItems/Write-RsFolderContent.ps1
@@ -78,10 +78,16 @@ function Write-RsFolderContent()
             $relativePath = Clear-Substring -string $item.FullName -substring $sourceFolder.FullName.TrimEnd("\") -position front
             $relativePath = Clear-Substring -string $relativePath -substring ("\" + $item.Name) -position back
             $relativePath = $relativePath.replace("\", "/")
-            
-            $parentFolder = $DestinationFolder + $relativePath
+            if($DestinationFolder -eq "/" -and $relativePath -ne "")
+            {
+                $parentFolder = $relativePath
+            }
+            else 
+            {
+                $parentFolder = $DestinationFolder + $relativePath               
+            }
 
-            Write-Output "Creating folder $parentFolder/$($item.Name)"
+            Write-Verbose "Creating folder $parentFolder/$($item.Name)"
             $Proxy.CreateFolder($item.Name, $parentFolder, $null) | Out-Null
         }
 


### PR DESCRIPTION
Fixing scripts for the special case where the target folder is the root folder. Concatenating target folder to the relative path to the new item has to be handled differently in these cases.