### PR TITLE
Updated Help on Get-RsFolderContent with more examples

### DIFF
--- a/Functions/CatalogItems/Get-RsFolderContent.ps1
+++ b/Functions/CatalogItems/Get-RsFolderContent.ps1
@@ -29,11 +29,28 @@ function Get-RsFolderContent
 
 
 	.EXAMPLE
-		Get-RsFolderContent -ReportServerUri 'http://localhost/reportserver_sql2012' -Path /
+		Get-RsFolderContent -ReportServerUri http://localhost/reportserver_sql2012 -Path /
 	   
 		Description
 		-----------
-		List all items under the root folder
+		List all items directly under the root of the named SSRS instance.
+
+	.EXAMPLE
+		Get-RsFolderContent -ReportServerUri http://localhost/ReportServer -Path / -Recurse
+	   
+		Description
+		-----------
+		Lists all items directly under the root of the SSRS instance and recursively under all sub-folders.
+
+    .EXAMPLE
+        Get-RsFolderContent -ReportServerUri http://localhost/ReportServer -Path '/SQL Server Performance Dashboard' | 
+        WHERE Name -Like Wait* | 
+        Out-RsCatalogItem -ReportServerUri http://localhost/ReportServer -Destination c:\SQLReports
+   
+        Description
+        -----------
+        Downloads all catalog items from folder '/SQL Server Performance Dashboard' with a name that starts with 'Wait' to folder 'C:\SQLReports'. 
+
 	#>
 	
 	[cmdletbinding()]


### PR DESCRIPTION
Cleaned up the original example by removing unnecessary tick marks.
Updated Help on Get-RsFolderContent with more examples; one to point out
the -Recurse parameter, the other is a duplicate of the example from the
Out-RsCatalogItem function to show that you can use the two commands
together via the pipeline.