### PR TITLE
Adding support for shared data source description

### DIFF
--- a/ReportingServicesTools/Functions/CatalogItems/New-RsDataSource.ps1
+++ b/ReportingServicesTools/Functions/CatalogItems/New-RsDataSource.ps1
@@ -15,6 +15,9 @@ function New-RsDataSource
         
         .PARAMETER Name
             Specify the name of the the new data source
+
+        .PARAMETER Description
+            Specify the description to be added to the data source.
         
         .PARAMETER Extension
             Specify the extension of the new data source (e.g. SQL, SQLAZURE, OLEDB, OLEDB-MD, etc.) For full list, please look at <Extensions>\<Data> node in C:\Program Files\Microsoft SQL Server\MSRS{VersionNumber}.{InstanceName}\Reporting Services\ReportServer\RSReportServer.config.
@@ -111,6 +114,9 @@ function New-RsDataSource
         [Parameter(Mandatory = $True)]
         [string]
         $Name,
+
+        [string]
+        $Description,
         
         [Parameter(Mandatory = $True)]
         [string]
@@ -168,6 +174,7 @@ function New-RsDataSource
 
     $namespace = $proxy.GetType().Namespace
     $datasourceDataType = "$namespace.DataSourceDefinition"
+    $propertyDataType = "$namespace.Property"
     $credentialRetrievalEnumType = "$namespace.CredentialRetrievalEnum"
 
     $datasource = New-Object $datasourceDataType
@@ -198,10 +205,19 @@ function New-RsDataSource
         throw (New-Object System.Exception("Exception occurred while converting credential retrieval to enum! $($_.Exception.Message)", $_.Exception))
     }
 
+    $additionalProperties = New-Object System.Collections.Generic.List[$propertyDataType]
+    if ($Description)
+    {
+        $descriptionProperty = New-Object $propertyDataType
+        $descriptionProperty.Name = 'Description'
+        $descriptionProperty.Value = $Description
+        $additionalProperties.Add($descriptionProperty)
+    }
+
     try
     {
         Write-Verbose "Creating data source..."
-        $Proxy.CreateDataSource($Name, $RsFolder, $Overwrite, $datasource, $null)
+        $Proxy.CreateDataSource($Name, $RsFolder, $Overwrite, $datasource, $additionalProperties)
         Write-Verbose "Data source created successfully!"
     }
     catch

--- a/Tests/CatalogItems/New-RsDataSource.Tests.ps1
+++ b/Tests/CatalogItems/New-RsDataSource.Tests.ps1
@@ -21,7 +21,7 @@ Function Get-ExistingDataExtension
 }
 
 Describe "New-RsDataSource" {
-    Context "Create RsDataSource with minimun parameters"{
+    Context "Create RsDataSource with minimal parameters"{
         # Declare datasource Name, Extension, CredentialRetrieval, and DataSource path.
         $dataSourceName = 'SutDataSourceMinParameters' + [guid]::NewGuid()
         $extension = Get-ExistingDataExtension
@@ -217,6 +217,30 @@ Describe "New-RsDataSource" {
         It "Should overwrite a datasource" {
             $dataSource.CredentialRetrieval | Should be  $credentialRetrievalChange 
             $dataSource.Count | Should Be 1
+        }
+        # Removing folders used for testing
+        Remove-RsCatalogItem -RsFolder $dataSourcePath
+    }
+
+    Context "Create RsDataSource with description"{
+        # Declare datasource Name, Extension, CredentialRetrieval, and DataSource path.
+        $dataSourceName = 'SutDataSourceDescription' + [guid]::NewGuid()
+        $extension = Get-ExistingDataExtension
+        $credentialRetrieval = 'None'
+        $dataSourcePath = '/' + $dataSourceName
+        $description = 'This is a description'
+        New-RsDataSource -RsFolder '/' -Name $dataSourceName -Extension $extension -CredentialRetrieval $credentialRetrieval -Description $description
+        $dataSource = Get-RsDataSource -Path $dataSourcePath
+        $proxy = New-RsWebServiceProxy
+        $properties = $proxy.GetProperties($dataSourcePath, $null)
+        It "Should be a new data source" {
+            $dataSource.Count | Should Be 1
+            $dataSource.Extension | Should Be $extension
+            $dataSource.CredentialRetrieval | Should Be $credentialRetrieval
+            $descriptionProperty = $properties | Where { $_.Name -eq 'Description' }
+            $descriptionProperty | Should Not BeNullOrEmpty
+            $descriptionProperty.Value | Should Be $description
+            
         }
         # Removing folders used for testing
         Remove-RsCatalogItem -RsFolder $dataSourcePath

--- a/Tests/CatalogItems/Set-RsDataSource.Tests.ps1
+++ b/Tests/CatalogItems/Set-RsDataSource.Tests.ps1
@@ -8,14 +8,27 @@ Function Get-ExistingDataExtension
 }
 
 Describe "Set-RsDataSource" {
-        Context "Set-RsDataSource with min parameters"{
+        $dataSourceName = $null
+        $extension = $null
+        $credentialRetrieval = $null
+        $dataSourcePath = $null
+
+        BeforeEach {
                 $dataSourceName = 'SutSetDataSource_MinParameter' + [guid]::NewGuid()
                 $extension = Get-ExistingDataExtension
                 $credentialRetrieval = 'None'
                 $dataSourcePath = '/' + $dataSourceName
                 New-RsDataSource -RsFolder '/' -Name $dataSourceName -Extension $extension -CredentialRetrieval $credentialRetrieval
                 $dataSourcePath =  '/' + $dataSourceName
+        }
+
+        AfterEach {
+                Remove-RsCatalogItem -RsFolder $dataSourcePath
+        }
+
+        It "Should set a RsDataSource with min parameters" {
                 $rsDataSource = Get-RsDataSource -Path $dataSourcePath 
+
                 # DataSource definition
                 $proxy = New-RsWebServiceProxy
                 $namespace = $proxy.GetType().Namespace
@@ -25,22 +38,14 @@ Describe "Set-RsDataSource" {
                 $datasource.CredentialRetrieval = 'Prompt'
                 $datasource.ConnectString =  'Data Source=localhost;Initial Catalog=ReportServer'
                 Set-RsDataSource -Path $dataSourcePath -DataSourceDefinition $datasource
-        
-                It "Should set a RsDataSource with min parameters" {
-                        $setRsDataSource = Get-RsDataSource -Path $dataSourcePath
-                        $rsDataSource.CredentialRetrieval | Should Not Be $setRsDataSource.CredentialRetrieval
-                }
-                Remove-RsCatalogItem -RsFolder $dataSourcePath
+
+                $setRsDataSource = Get-RsDataSource -Path $dataSourcePath
+                $rsDataSource.CredentialRetrieval | Should Not Be $setRsDataSource.CredentialRetrieval
         }
 
-        Context "Set-RsDataSource with Proxy parameter"{
-                $dataSourceName = 'SutSetDataSource_ProxyParameter' + [guid]::NewGuid()
-                $extension = Get-ExistingDataExtension
-                $credentialRetrieval = 'None'
-                $dataSourcePath = '/' + $dataSourceName
-                New-RsDataSource -RsFolder '/' -Name $dataSourceName -Extension $extension -CredentialRetrieval $credentialRetrieval 
-                $dataSourcePath =  '/' + $dataSourceName
+        It "Should set a RsDataSource with proxy Parameter" {
                 $rsDataSource = Get-RsDataSource -Path $dataSourcePath 
+
                 # DataSource definition
                 $proxy = New-RsWebServiceProxy
                 $namespace = $proxy.GetType().Namespace
@@ -50,23 +55,15 @@ Describe "Set-RsDataSource" {
                 $datasource.CredentialRetrieval = 'Prompt'
                 $datasource.ConnectString =  'Data Source=localhost;Initial Catalog=ReportServer'
                 Set-RsDataSource -Path $dataSourcePath -DataSourceDefinition $datasource -Proxy $proxy
-
-                It "Should set a RsDataSource with proxy Parameter" {
-                        $setRsDataSource = Get-RsDataSource -Path $dataSourcePath
-                        $rsDataSource.CredentialRetrieval | Should Not Be $setRsDataSource.CredentialRetrieval
-                }
-                Remove-RsCatalogItem -RsFolder $dataSourcePath
+                
+                $setRsDataSource = Get-RsDataSource -Path $dataSourcePath
+                $rsDataSource.CredentialRetrieval | Should Not Be $setRsDataSource.CredentialRetrieval
         }
 
-        Context "Set-RsDataSource with ReportServerUri parameter"{
-                $dataSourceName = 'SutSetDataSource_ReportServerUriParameter' + [guid]::NewGuid()
-                $extension = Get-ExistingDataExtension
-                $credentialRetrieval = 'None'
-                $dataSourcePath = '/' + $dataSourceName
-                New-RsDataSource -RsFolder '/' -Name $dataSourceName -Extension $extension -CredentialRetrieval $credentialRetrieval
-                $dataSourcePath =  '/' + $dataSourceName
+        It "Should set a RsDataSource with ReportServerUri parameter" {
                 $rsDataSource = Get-RsDataSource -Path $dataSourcePath 
                 $reportServerUri = 'http://localhost/reportserver'
+
                 # DataSource definition
                 $proxy = New-RsWebServiceProxy
                 $namespace = $proxy.GetType().Namespace
@@ -76,23 +73,15 @@ Describe "Set-RsDataSource" {
                 $datasource.CredentialRetrieval = 'Prompt'
                 $datasource.ConnectString =  'Data Source=localhost;Initial Catalog=ReportServer'
                 Set-RsDataSource -Path $dataSourcePath -DataSourceDefinition $datasource -ReportServerUri $reportServerUri
-        
-                It "Should set a RsDataSource with ReportServerUri parameter" {
-                        $setRsDataSource = Get-RsDataSource -Path $dataSourcePath
-                        $rsDataSource.CredentialRetrieval | Should Not Be $setRsDataSource.CredentialRetrieval
-                }
-                Remove-RsCatalogItem -RsFolder $dataSourcePath
+
+                $setRsDataSource = Get-RsDataSource -Path $dataSourcePath
+                $rsDataSource.CredentialRetrieval | Should Not Be $setRsDataSource.CredentialRetrieval
         }
 
-        Context "Set-RsDataSource with ReportServerUri and Proxy parameter"{
-                $dataSourceName = 'SutSetDataSource_ReportServerUriProxyParameter' + [guid]::NewGuid()
-                $extension = Get-ExistingDataExtension
-                $credentialRetrieval = 'None'
-                $dataSourcePath = '/' + $dataSourceName
-                New-RsDataSource -RsFolder '/' -Name $dataSourceName -Extension $extension -CredentialRetrieval $credentialRetrieval 
-                $dataSourcePath =  '/' + $dataSourceName
+        It "Should set a RsDataSource with Proxy and ReportServerUri parameter" {
                 $rsDataSource = Get-RsDataSource -Path $dataSourcePath 
                 $reportServerUri = 'http://localhost/reportserver'
+
                 # DataSource definition
                 $proxy = New-RsWebServiceProxy
                 $namespace = $proxy.GetType().Namespace
@@ -102,11 +91,21 @@ Describe "Set-RsDataSource" {
                 $datasource.CredentialRetrieval = 'Prompt'
                 $datasource.ConnectString =  'Data Source=localhost;Initial Catalog=ReportServer'
                 Set-RsDataSource -Path $dataSourcePath -DataSourceDefinition $datasource -Proxy $proxy -ReportServerUri $reportServerUri
-        
-                It "Should set a RsDataSource with Proxy and ReportServerUri parameter" {
-                        $setRsDataSource = Get-RsDataSource -Path $dataSourcePath
-                        $rsDataSource.CredentialRetrieval | Should Not Be $setRsDataSource.CredentialRetrieval
-                }
-                Remove-RsCatalogItem -RsFolder $dataSourcePath
+
+                $setRsDataSource = Get-RsDataSource -Path $dataSourcePath
+                $rsDataSource.CredentialRetrieval | Should Not Be $setRsDataSource.CredentialRetrieval
+        }
+
+        It "Should set description of data source" {
+                # updating description
+                $originalDataSource = Get-RsDataSource -Path $dataSourcePath 
+                $description = 'This is a description'
+                Set-RsDataSource -Path $dataSourcePath -DataSourceDefinition $originalDataSource -Description $description
+
+                # verifying property got created
+                $proxy = New-RsWebServiceProxy
+                $descriptionProperty = $proxy.GetProperties($dataSourcePath, $null) | Where { $_.Name -eq 'Description' }
+                $descriptionProperty | Should Not BeNullOrEmpty
+                $descriptionProperty.Value | Should be $description
         }
 }


### PR DESCRIPTION
Fixes #39 

Changes proposed in this pull request:
 - Added option to specify a description when creating or modifying a Shared Data Source.

How to test this code:
 - Tests were added.

Has been tested on (remove any that don't apply):
 - Powershell 4 
 - Windows 10 
 - Power BI Report Server
