### PR TITLE
Set-RsSubscription - Change the logic of validation if destination report exists

### DIFF
--- a/ReportingServicesTools/Functions/CatalogItems/Set-RsSubscription.ps1
+++ b/ReportingServicesTools/Functions/CatalogItems/Set-RsSubscription.ps1
@@ -105,19 +105,20 @@ function Set-RsSubscription
         {
             foreach ($sub in $Subscription) 
             {
-                if ($RsFolder) {
+                if ($RsFolder)
+                {
                     $Path = "$RsFolder/$($sub.Report)"
+                }
+                else 
+                {
+                    $RsFolder = (Split-Path $Path -Parent).Replace("\", "/")
                 }
                 
                 Write-Verbose "Validating if destination exists..."
                 
-                try 
+                if (((Get-RsFolderContent -Proxy $Proxy -RsFolder $RsFolder | Where-Object Path -eq $Path).Count) -eq 0)
                 {
-                    $report = Get-RsItemReference -Proxy $Proxy -Path $Path -ErrorAction SilentlyContinue
-                }
-                catch
-                {
-                    Write-Warning "Can't find the report $Path. Skipping. $($_.Exception.Message)"
+                    Write-Warning "Can't find the report $Path. Skipping."
                     Continue
                 }
                 


### PR DESCRIPTION
A user reported that receives an error when try to copy the subscription for a report type 'LinkedReport'.

> You get the error ItemType ‘LinkedReport’ is not supported by this.

This PR, includes a better way to validate if the destination report exists.
Before was using the Get-RsItemReference to validate the existence of it but this is not the correct way.