### PR TITLE
add Update-RsSubscriptions

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,9 +1,9 @@
 **Do you want to request a *feature* or report a *bug*?**
-
+feature
 **What is the current behavior?**
-
+a new function to update an existing subscription enddate or startdatetime
 **If the current behavior is a bug, please provide the steps to reproduce and if possible a minimal demo of the problem.**
 
 **What is the expected behavior?**
-
+to update an existing subscription
 **Which versions of Powershell and which OS are affected by this issue? Did this work in previous versions of our scripts?**

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,12 +1,15 @@
-Fixes # .
+Fixes # 66.
 
 Changes proposed in this pull request:
- - 
- - 
+ - update/add existing subscription enddate
+ - update startdatetime of existing subscription
  - 
 
 How to test this code:
  - 
+$proxy = "http://SSRS/Reportserver"
+get-rssubscription -ReportServerUri $proxy -path '/Operations/REPORT' | Update-RsSubscription -ReportServerUri $proxy -EndDate 9/10/2020  -StartDateTime 7/1/2015
+
  - 
  - 
 

--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ The following is a list of commands which are available for you to use once you 
 |Set-RsEmailSettingsAsNTLMAuth|This command configures the SQL Server Reporting Services email settings to use NTLM authentication.|
 |Set-RsSharedDataSource|This command links a report or a dataset to a data source.|
 |Set-RsUrlReservation|This command configures the SQL Server Reporting Services URLs.|
+|Update-RsSubscription|This command updates existing subscriptions piped from Get-RsSubscription|
 |Write-RsCatalogItem|This command uploads a report, a dataset or a data source.|
 |Write-RsFolderContent|This uploads all reports, datasets and data sources in a folder.|
 
@@ -98,7 +99,7 @@ For debugging you can set the verbose logging with `$VerbosePreference = "contin
 
 ## Test
 
-For running tests locally you need a local default instance of  SQL Server Reporting Services and Pester
+For running tests locally you need a local default instance of SQL Server Reporting Services and Pester
 
 To install Pester execute
 ```powershell

--- a/README.md
+++ b/README.md
@@ -1,4 +1,3 @@
-[![Build status](https://ci.appveyor.com/api/projects/status/github/microsoft/reportingservicestools?branch=master&svg=true)](https://ci.appveyor.com/project/jtarquino/reportingservicestools)
 # Reporting Services PowerShell
 SQL Server Reporting Services PowerShell utilities 
 

--- a/README.md
+++ b/README.md
@@ -10,6 +10,9 @@ All of our scripts were written with the assumption that you will be executing t
 
 ## PowerShell Version
 Please ensure you're running PowerShell version 3.0+
+```powershell
+$PSVersionTable
+```
 
 ## Install
 ```powershell
@@ -31,21 +34,32 @@ The following is a list of commands which are available for you to use once you 
 |Command|Description|
 |-------|-----------|
 |Backup-RsEncryptionKey|This command backs up the encryption key used by SQL Server Reporting Services to protect sensitive content.|
+|Export-RsSubscriptionXml|This command exports a collection of subscriptions to an XML file on disk.|
 |Get-RsFolderContent|This command lists all catalog items under a folder.|
 |Get-RsDataSource|This command lists information about data source located at the specified path.|
 |Get-RsItemReferences|This commands sets the item references of a report or a dataset.|
 |Get-RsCatalogItemRole|This command retrieves access on catalog items for users or groups.|
+|Get-RsSubscription|This command retrieves information about subscriptions for a report.|
 |Grant-AccessOnCatalogItem|This command grants access on catalog item to users or groups.|
 |Grant-AccessToRs|This command grants access to SQL Server Reporting Services to users or groups.|
+|Import-RsSubscriptionXml|This command imports a collection of subscriptions from an XML file on disk, typically created via Export-RsSubscriptionXml.|
 |Initialize-Rs|This command initializes Report Server post installation. The database MUST be configured and URLs MUST be reserved prior to running this command.|
 |New-RsConfigurationSettingObject|This command creates a new RSConfigurationSettingObject which is used to interact with the WMI Provider.|
 |New-RsDataSource|This command creates/overwrites data source to the specified path.|
 |New-RsFolder|This command creates a new folder in the specified path.|
+|New-RsRestFolder|This command creates a new folder in the specified path using the REST Endpoint.|
+|New-RsRestSession|This command creates a session object to be specified for all subsequent calls to the REST Endpoint.|
+|New-RsSubscription|This command adds a new subscription to an existing report.|
+|New-RsScheduleXml|This command creates an XML string definition of a subscription schedule. For use with the -Schedule parameter or New-RsSubscription.|
 |New-RsWebServiceProxy|This command creates a new Web Service Proxy which is used to interact with the SOAP Endpoint.|
 |Out-RsCatalogItem|This command downloads a catalog item.|
 |Out-RsFolderContent|This command all catalog items in folder.|
+|Out-RsRestFolderContent|This command downloads all catalog items under a folder using the REST Endpoint.|
+|Out-RsRestCatalogItem|This command downloads a catalog item using the REST Endpoint.|
 |Register-PowerBI|This command registers Power BI information with SQL Server Reporting Services.|
 |Remove-RsCatalogItem|This command removes catalog item located at the specified path.|
+|Remove-RsRestCatalogItem|This command removes catalog item located at the specified path using the REST Endpoint.|
+|Remove-RsRestFolder|This command removes folder located at the specified path using the REST Endpoint.|
 |Restore-RsEncryptionKey|This command restores encryption key on to the SQL Server Reporting Services.|
 |Revoke-AccessOnCatalogItem|This command revokes access on catalog item from users or groups.|
 |Revoke-AccessToRs|This command revokes access on SQL Server Reporting Services from users or groups.|
@@ -58,10 +72,14 @@ The following is a list of commands which are available for you to use once you 
 |Set-RsEmailSettingsAsNoAuth|This command configures the SQL Server Reporting Services email settings to use no authentication.|
 |Set-RsEmailSettingsAsNTLMAuth|This command configures the SQL Server Reporting Services email settings to use NTLM authentication.|
 |Set-RsSharedDataSource|This command links a report or a dataset to a data source.|
+|Set-RsSubscription|This command adds a retrieved subscription to an existing report. For use with Get-RsSubscription.|
 |Set-RsUrlReservation|This command configures the SQL Server Reporting Services URLs.|
+|Set-PbiRsUrlReservation|This command configures the Power BI Report Server URLs.|
 |Update-RsSubscription|This command updates existing subscriptions piped from Get-RsSubscription|
-|Write-RsCatalogItem|This command uploads a report, a dataset or a data source.|
+|Write-RsCatalogItem|This command uploads a report, a dataset or a data source using the SOAP Endpoint..|
 |Write-RsFolderContent|This uploads all reports, datasets and data sources in a folder.|
+|Write-RsRestCatalogItem|This command uploads a report, a dataset or a mobile report using the REST Endpoint.|
+|Write-RsRestFolderContent|This uploads all reports, datasets, data sources, mobile reports and Power BI reports in a folder using the REST Endpoint.|
 
 ## SQL Server Versions
 
@@ -99,7 +117,7 @@ For debugging you can set the verbose logging with `$VerbosePreference = "contin
 
 ## Test
 
-For running tests locally you need a local default instance of SQL Server Reporting Services and Pester
+For running tests locally you need a local default instance of  SQL Server Reporting Services and Pester
 
 To install Pester execute
 ```powershell

--- a/ReportingServicesTools/Functions/CatalogItems/Update-RsSubscription.ps1
+++ b/ReportingServicesTools/Functions/CatalogItems/Update-RsSubscription.ps1
@@ -1,0 +1,117 @@
+# Copyright (c) 2016 Microsoft Corporation. All Rights Reserved.
+# Licensed under the MIT License (MIT)
+
+
+function Update-RsSubscription
+{
+  <#
+        .SYNOPSIS
+            This script will update subscriptions piped from get-RsSubscriptions
+
+        .DESCRIPTION
+            This script will take the custom object producted by get-RSSubscription and use the data to update the 
+            matchdata xml to either a new startdatetime, or enddate.
+
+        .PARAMETER ReportServerUri
+            Specify the Report Server URL to your SQL Server Reporting Services Instance.
+            Use the "Connect-RsReportServer" function to set/update a default value.
+
+        .PARAMETER Credential
+            Specify the password to use when connecting to your SQL Server Reporting Services Instance.
+            Use the "Connect-RsReportServer" function to set/update a default value.
+
+        .PARAMETER Proxy
+            Report server proxy to use.
+            Use "New-RsWebServiceProxy" to generate a proxy object for reuse.
+            Useful when repeatedly having to connect to multiple different Report Server.
+
+        .EXAMPLE
+            $proxy = "http://ssrs-t-1234/Reportserver"
+            Get-RsSubscription -ReportServerUri $proxy -path '/Finance/ImportantReports' | 
+            where description -eq 'super important' | Update-RsSubscription -ReportServerUri $proxy -EndDate 9/9/2099
+
+            assign proxy to variable for reuse.
+            use get-rsssubscripion to find the 'super important' report in my /finance/importantreports path. Then Pipe the results
+            to update-RsSubscription where we reuse the same $proxy to update the EndDate to 9/9/2099.
+
+        .EXAMPLE
+            $proxy = "http://ssrs-t-1234/Reportserver"
+
+            [psobject]$subscriptions = Get-RsSubscription -ReportServerUri $proxy -path '/Finance/ImportantReports' | where description -eq 'super important' 
+            $subscriptions | Update-RsSubscription -ReportServerUri $proxy -EndDate 9/9/2099 -StartDate 1/1/2016
+
+            assign proxy to variable for reuse. 
+            Then create a psobject variable to store the objects created from get-RSSubscription.
+            Then Pipe the results to Update-RSSubscription where we reuse the same $proxy to update the EndDate to 9/9/2999 and StartDate to 1/1/2016
+        
+    #>
+    
+  [CmdletBinding()]
+  param (
+    [string]
+    $ReportServerUri,
+    [Alias('ReportServerCredentials')]
+    [System.Management.Automation.PSCredential]
+    $Credential,
+    $Proxy,
+    [parameter(Mandatory = $false)]
+    [DateTime]$StartDateTime,
+    [parameter(Mandatory = $false)]
+    [DateTime]$EndDate,
+    [Parameter(Mandatory = $true, ValueFromPipeLine)]
+    [PSCustomObject[]]$SubProperties
+        
+  )
+    
+  Begin
+  {
+    $Proxy = New-RsWebServiceProxyHelper -BoundParameters $PSBoundParameters
+    
+  }
+  Process
+  {
+    Write-Verbose "Updating Subscriptions..."
+    try
+    {
+      [xml]$XMLMatch = $SubProperties.MatchData
+            
+      if ($StartDateTime)
+      {
+        $XMLMatch.ScheduleDefinition.StartDateTime.InnerText = $StartDateTime
+      }
+    
+      if ($EndDate)
+      {
+        #check to see if end date exists as a node
+        $EndExists = $XMLMatch.SelectNodes("//*") | Select-Object name | Where-Object name -eq "EndDate"
+        #if no enddate create child node
+        if ($EndExists -eq $null)
+        {
+          $child = $XMLMatch.CreateElement("EndDate")
+          $child.InnerText = $EndDate
+        
+          $XMLMatch.ScheduleDefinition.AppendChild($child)
+        
+        }
+        else
+        {
+          #if enddate node exists update  
+          $XMLMatch.ScheduleDefinition.EndDate.InnerText = $EndDate         
+        } 
+        
+      }
+    
+      if ($StartDateTime -ne $null -or $EndDate -ne $null)
+      {
+        $null = $Proxy.SetSubscriptionProperties($SubProperties.subscriptionID, $SubProperties.DeliverySettings, $SubProperties.Description, $SubProperties.EventType, $XMLMatch.OuterXml, $SubProperties.Values) 
+        Write-Verbose "subscription $($SubProperties.subscriptionId) for $($SubProperties.report) report successfully updated!"
+      }
+    }
+    Catch
+    {
+      throw (New-Object System.Exception("Exception while updating subscription(s)! $($_.Exception.Message)", $_.Exception))
+    }
+    
+  }
+}
+

--- a/ReportingServicesTools/Functions/CatalogItems/Update-RsSubscription.ps1
+++ b/ReportingServicesTools/Functions/CatalogItems/Update-RsSubscription.ps1
@@ -6,11 +6,11 @@ function Update-RsSubscription
 {
   <#
         .SYNOPSIS
-            This script will update subscriptions piped from get-RsSubscriptions
+            This script will update subscriptions piped from Get-RsSubscriptions
 
         .DESCRIPTION
             This script will take the custom object producted by get-RSSubscription and use the data to update the 
-            matchdata xml to either a new startdatetime, or enddate.
+            matchdata xml to either a new startdatetime, enddate, or owner.
 
         .PARAMETER ReportServerUri
             Specify the Report Server URL to your SQL Server Reporting Services Instance.
@@ -25,24 +25,37 @@ function Update-RsSubscription
             Use "New-RsWebServiceProxy" to generate a proxy object for reuse.
             Useful when repeatedly having to connect to multiple different Report Server.
 
+        .PARAMETER StartDateTime
+            StartDateTime to change Start Date and Time of subscription.
+        
+        .PARAMETER EndDate
+            Used to change the EndDate of subscription. 
+
+        .PARAMETER Owner
+            Used to change the owner of a subscription. 
+            
+          
         .EXAMPLE
-            $proxy = "http://ssrs-t-1234/Reportserver"
-            Get-RsSubscription -ReportServerUri $proxy -path '/Finance/ImportantReports' | 
-            where description -eq 'super important' | Update-RsSubscription -ReportServerUri $proxy -EndDate 9/9/2099
+            Get-RsSubscription -path '/Finance/ImportantReports' | Update-RsSubscription -EndDate 9/9/2099
 
-            assign proxy to variable for reuse.
-            use get-rsssubscripion to find the 'super important' report in my /finance/importantreports path. Then Pipe the results
-            to update-RsSubscription where we reuse the same $proxy to update the EndDate to 9/9/2099.
+            Description
+            -----------
+            Update all subscriptions on localhost associated with '/finance/ImportantReports' to have an EndDate of 9/9/2099
 
         .EXAMPLE
-            $proxy = "http://ssrs-t-1234/Reportserver"
+            Get-RsSubscription -path '/Finance/ImportantReports' | Update-RsSubscription -StartDateTime "1/9/2017 9am"
 
-            [psobject]$subscriptions = Get-RsSubscription -ReportServerUri $proxy -path '/Finance/ImportantReports' | where description -eq 'super important' 
-            $subscriptions | Update-RsSubscription -ReportServerUri $proxy -EndDate 9/9/2099 -StartDate 1/1/2016
+            Description
+            -----------
+            Update all subscriptions on localhost associated with '/finance/ImportantReports' to have a startdate of 1/9/2017 and time of 9am
+        
+        .EXAMPLE
+            Get-RsSubscription -path '/Finance/ImportantReports' | Update-RsSubscription -Owner "Warren"
 
-            assign proxy to variable for reuse. 
-            Then create a psobject variable to store the objects created from get-RSSubscription.
-            Then Pipe the results to Update-RSSubscription where we reuse the same $proxy to update the EndDate to 9/9/2999 and StartDate to 1/1/2016
+            Description
+            -----------
+            Update all subscriptions on localhost associated with '/finance/ImportantReports' to have an owner of "Warren".
+            The user being updated needs to have the correct permissions in order to successfully update the owner.
         
     #>
     
@@ -50,15 +63,22 @@ function Update-RsSubscription
   param (
     [string]
     $ReportServerUri,
-    [Alias('ReportServerCredentials')]
+    
     [System.Management.Automation.PSCredential]
     $Credential,
+
     $Proxy,
+
     [parameter(Mandatory = $false)]
     [DateTime]$StartDateTime,
+
     [parameter(Mandatory = $false)]
     [DateTime]$EndDate,
-    [Parameter(Mandatory = $true, ValueFromPipeLine)]
+
+    [parameter(Mandatory = $False)]
+    [string]$Owner,
+
+    [Parameter(Mandatory=$true,ValueFromPipeLine)]
     [PSCustomObject[]]$SubProperties
         
   )
@@ -71,45 +91,50 @@ function Update-RsSubscription
   Process
   {
     Write-Verbose "Updating Subscriptions..."
-    try
-    {
-      [xml]$XMLMatch = $SubProperties.MatchData
+try
+ {
+   [xml]$XMLMatch = $SubProperties.MatchData
+
+    if ($owner){
+    $proxy.ChangeSubscriptionOwner($SubProperties.subscriptionID,$owner)
+    }
+
             
-      if ($StartDateTime)
-      {
+    if ($StartDateTime)
+    {
         $XMLMatch.ScheduleDefinition.StartDateTime.InnerText = $StartDateTime
-      }
+    }
     
-      if ($EndDate)
+    if ($EndDate)
+    {
+      #check to see if end date exists as a node
+      $EndExists = $XMLMatch.SelectNodes("//*") | Select-Object name | Where-Object name -eq "EndDate"
+      #if no enddate create child node
+      if ($EndExists -eq $null)
       {
-        #check to see if end date exists as a node
-        $EndExists = $XMLMatch.SelectNodes("//*") | Select-Object name | Where-Object name -eq "EndDate"
-        #if no enddate create child node
-        if ($EndExists -eq $null)
-        {
-          $child = $XMLMatch.CreateElement("EndDate")
-          $child.InnerText = $EndDate
+        $child = $XMLMatch.CreateElement("EndDate")
+        $child.InnerText = $EndDate
         
-          $XMLMatch.ScheduleDefinition.AppendChild($child)
+        $XMLMatch.ScheduleDefinition.AppendChild($child)
         
-        }
-        else
-        {
+      }
+      else
+      {
           #if enddate node exists update  
           $XMLMatch.ScheduleDefinition.EndDate.InnerText = $EndDate         
-        } 
+      } 
         
-      }
+    }
     
-      if ($StartDateTime -ne $null -or $EndDate -ne $null)
-      {
-        $null = $Proxy.SetSubscriptionProperties($SubProperties.subscriptionID, $SubProperties.DeliverySettings, $SubProperties.Description, $SubProperties.EventType, $XMLMatch.OuterXml, $SubProperties.Values) 
-        Write-Verbose "subscription $($SubProperties.subscriptionId) for $($SubProperties.report) report successfully updated!"
-      }
+    if ($StartDateTime -ne $null -or $EndDate -ne $null)
+    {
+      $null = $Proxy.SetSubscriptionProperties($SubProperties.subscriptionID, $SubProperties.DeliverySettings, $SubProperties.Description, $SubProperties.EventType, $XMLMatch.OuterXml, $SubProperties.Values) 
+      Write-Verbose "subscription $($SubProperties.subscriptionId) for $($SubProperties.report) report successfully updated!"
+    }
     }
     Catch
     {
-      throw (New-Object System.Exception("Exception while updating subscription(s)! $($_.Exception.Message)", $_.Exception))
+     throw (New-Object System.Exception("Exception while updating subscription(s)! $($_.Exception.Message)", $_.Exception))
     }
     
   }

--- a/ReportingServicesTools/ReportingServicesTools.psd1
+++ b/ReportingServicesTools/ReportingServicesTools.psd1
@@ -94,7 +94,8 @@
         'Write-RsFolderContent',
         'Get-RsSubscription',
         'Set-RsSubscription',
-        'Remove-RsSubscription'
+        'Remove-RsSubscription',
+        'Update-RsSubscription'
     )
     
     # Cmdlets to export from this module

--- a/ReportingServicesTools/ReportingServicesTools.psd1
+++ b/ReportingServicesTools/ReportingServicesTools.psd1
@@ -7,7 +7,7 @@
     RootModule = 'ReportingServicesTools.psm1'
     
     # Version number of this module.
-    ModuleVersion = '0.0.2.6'
+    ModuleVersion = '0.0.3.3'
     
     # ID used to uniquely identify this module
     GUID = '9d139310-ce45-41ce-8e8b-d76335aa1789'
@@ -64,21 +64,33 @@
     FunctionsToExport = @(
         'Backup-RsEncryptionKey',
         'Connect-RsReportServer',
+        'Export-RsSubscriptionXml',
+        'Get-RsCatalogItemRole',
         'Get-RsDataSource',
         'Get-RsFolderContent',
         'Get-RsItemReference',
-        'Get-RsCatalogItemRole',
+        'Get-RsSubscription',
         'Grant-RsCatalogItemRole',
         'Grant-RsSystemRole',
-        'Initialize-Rs',
+        'Import-RsSubscriptionXml',
+	    'Initialize-Rs',
         'New-RsConfigurationSettingObject',
         'New-RsDataSource',
         'New-RsFolder',
+        'New-RsRestFolder',
+        'New-RsRestSession',
+        'New-RsSubscription',
+        'New-RsScheduleXML',
         'New-RsWebServiceProxy',
         'Out-RsCatalogItem',
         'Out-RsFolderContent',
+        'Out-RsRestCatalogItem',
+        'Out-RsRestFolderContent',
         'Register-RsPowerBI',
         'Remove-RsCatalogItem',
+        'Remove-RsRestFolder',
+        'Remove-RsRestCatalogItem',
+        'Remove-RsSubscription',
         'Restore-RsEncryptionKey',
         'Revoke-RsCatalogItemAccess',
         'Revoke-RsSystemAccess',
@@ -89,12 +101,13 @@
         'Set-RsDataSourcePassword',
         'Set-RsDataSourceReference',
         'Set-RsEmailSettings',
-        'Set-RsUrlReservation'
+        'Set-RsSubscription',
+        'Set-RsUrlReservation',
+        'Set-PbiRsUrlReservation',
         'Write-RsCatalogItem',
         'Write-RsFolderContent',
-        'Get-RsSubscription',
-        'Set-RsSubscription',
-        'Remove-RsSubscription',
+        'Write-RsRestCatalogItem',
+        'Write-RsRestFolderContent',
         'Update-RsSubscription'
     )
     

--- a/Tests/CatalogItems/Update-RsSubscription.Tests.ps1
+++ b/Tests/CatalogItems/Update-RsSubscription.Tests.ps1
@@ -1,0 +1,307 @@
+﻿# Copyright (c) 2016 Microsoft Corporation. All Rights Reserved.
+# Licensed under the MIT License (MIT)
+
+#Not in use right now - need email configuration on the report server
+Function Get-NewSubscription
+{
+
+    [xml]$matchData = '<?xml version="1.0" encoding="utf-16" standalone="yes"?><ScheduleDefinition xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><StartDateTime xmlns="http://schemas.microsoft.com/sqlserver/reporting/2010/03/01/ReportServer">2017-07-14T08:00:00.000+01:00</StartDateTime><WeeklyRecurrence xmlns="http://schemas.microsoft.com/sqlserver/reporting/2010/03/01/ReportServer"><WeeksInterval>1</WeeksInterval><DaysOfWeek><Monday>true</Monday><Tuesday>true</Tuesday><Wednesday>true</Wednesday><Thursday>true</Thursday><Friday>true</Friday></DaysOfWeek></WeeklyRecurrence></ScheduleDefinition>'
+    
+    $proxy = New-RsWebServiceProxy
+    $namespace = $proxy.GetType().NameSpace
+
+    $ExtensionSettingsDataType = "$namespace.ExtensionSettings"
+    $ParameterValueOrFieldReference = "$namespace.ParameterValueOrFieldReference[]"
+    $ParameterValueDataType = "$namespace.ParameterValue"
+
+    #Set ExtensionSettings
+    $ExtensionSettings = New-Object $ExtensionSettingsDataType
+                    
+    $ExtensionSettings.Extension = "Report Server Email"
+
+    #Set ParameterValues
+    $ParameterValues = New-Object $ParameterValueOrFieldReference -ArgumentList 8
+
+    $to = New-Object $ParameterValueDataType
+    $to.Name = "TO";
+    $to.Value = "mail@rstools.com"; 
+    $ParameterValues[0] = $to;
+
+    $replyTo = New-Object $ParameterValueDataType
+    $replyTo.Name = "ReplyTo";
+    $replyTo.Value ="dank@rstools.com";
+    $ParameterValues[1] = $replyTo;
+
+    $includeReport = New-Object $ParameterValueDataType
+    $includeReport.Name = "IncludeReport";
+    $includeReport.Value = "False";
+    $ParameterValues[2] = $includeReport;
+
+    $renderFormat = New-Object $ParameterValueDataType
+    $renderFormat.Name = "RenderFormat";
+    $renderFormat.Value = "MHTML";
+    $ParameterValues[3] = $renderFormat;
+
+    $priority = New-Object $ParameterValueDataType
+    $priority.Name = "Priority";
+    $priority.Value = "NORMAL";
+    $ParameterValues[4] = $priority;
+
+    $subject = New-Object $ParameterValueDataType
+    $subject.Name = "Subject";
+    $subject.Value = "Your sales report";
+    $ParameterValues[5] = $subject;
+
+    $comment = New-Object $ParameterValueDataType
+    $comment.Name = "Comment";
+    $comment.Value = "Here is the link to your report.";
+    $ParameterValues[6] = $comment;
+
+    $includeLink = New-Object $ParameterValueDataType
+    $includeLink.Name = "IncludeLink";
+    $includeLink.Value = "True";
+    $ParameterValues[7] = $includeLink;
+
+    $ExtensionSettings.ParameterValues = $ParameterValues
+
+    $subscription = [pscustomobject]@{
+        DeliverySettings      = $ExtensionSettings
+        Description           = "Send email to mail@rstools.com"
+        EventType             = "TimedSubscription"
+        IsDataDriven          = $false
+	    MatchData             = $matchData.OuterXml
+    }
+    
+    return $subscription
+}
+
+Function Get-NewFileShareSubscription
+{
+
+    [xml]$matchData = '<?xml version="1.0" encoding="utf-16" standalone="yes"?><ScheduleDefinition xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><StartDateTime xmlns="http://schemas.microsoft.com/sqlserver/reporting/2010/03/01/ReportServer">2017-07-14T08:00:00.000+01:00</StartDateTime><WeeklyRecurrence xmlns="http://schemas.microsoft.com/sqlserver/reporting/2010/03/01/ReportServer"><WeeksInterval>1</WeeksInterval><DaysOfWeek><Monday>true</Monday><Tuesday>true</Tuesday><Wednesday>true</Wednesday><Thursday>true</Thursday><Friday>true</Friday></DaysOfWeek></WeeklyRecurrence></ScheduleDefinition>'
+    
+    $proxy = New-RsWebServiceProxy
+    $namespace = $proxy.GetType().NameSpace
+
+    $ExtensionSettingsDataType = "$namespace.ExtensionSettings"
+    $ParameterValueOrFieldReference = "$namespace.ParameterValueOrFieldReference[]"
+    $ParameterValueDataType = "$namespace.ParameterValue"
+
+    #Set ExtensionSettings
+    $ExtensionSettings = New-Object $ExtensionSettingsDataType
+                    
+    $ExtensionSettings.Extension = "Report Server FileShare"
+
+    #Set ParameterValues
+    $ParameterValues = New-Object $ParameterValueOrFieldReference -ArgumentList 7
+
+    $to = New-Object $ParameterValueDataType
+    $to.Name = "PATH";
+    $to.Value = "\\unc\path"; 
+    $ParameterValues[0] = $to;
+
+    $replyTo = New-Object $ParameterValueDataType
+    $replyTo.Name = "FILENAME";
+    $replyTo.Value ="Report";
+    $ParameterValues[1] = $replyTo;
+
+    $includeReport = New-Object $ParameterValueDataType
+    $includeReport.Name = "FILEEXTN";
+    $includeReport.Value = "True";
+    $ParameterValues[2] = $includeReport;
+
+    $renderFormat = New-Object $ParameterValueDataType
+    $renderFormat.Name = "USERNAME";
+    $renderFormat.Value = "user";
+    $ParameterValues[3] = $renderFormat;
+
+    $priority = New-Object $ParameterValueDataType
+    $priority.Name = "RENDER_FORMAT";
+    $priority.Value = "PDF";
+    $ParameterValues[4] = $priority;
+
+    $subject = New-Object $ParameterValueDataType
+    $subject.Name = "WRITEMODE";
+    $subject.Value = "Overwrite";
+    $ParameterValues[5] = $subject;
+
+    $comment = New-Object $ParameterValueDataType
+    $comment.Name = "DEFAULTCREDENTIALS";
+    $comment.Value = "False";
+    $ParameterValues[6] = $comment;
+
+    $ExtensionSettings.ParameterValues = $ParameterValues
+
+    $subscription = [pscustomobject]@{
+        DeliverySettings      = $ExtensionSettings
+        Description           = "Shared on \\unc\path"
+        EventType             = "TimedSubscription"
+        IsDataDriven          = $false
+	    MatchData             = $matchData.OuterXml
+    }
+    
+    return $subscription
+}
+
+Function Set-FolderReportDataSource
+{
+    param (
+        [string]
+        $NewFolderPath
+    )
+    
+    
+    $localResourcesPath =   (Get-Item -Path ".\").FullName  + '\Tests\CatalogItems\testResources\emptyReport.rdl'
+    $null = Write-RsCatalogItem -Path $localResourcesPath -RsFolder $NewFolderPath
+    $report = (Get-RsFolderContent -RsFolder $NewFolderPath )| Where-Object TypeName -eq 'Report'
+
+    $localResourcesPath =   (Get-Item -Path ".\").FullName  + '\Tests\CatalogItems\testResources\UnDataset.rsd'
+    $null = Write-RsCatalogItem -Path $localResourcesPath -RsFolder $NewFolderPath
+    $dataSet = (Get-RsFolderContent -RsFolder $NewFolderPath ) | Where-Object TypeName -eq 'DataSet'
+    $DataSetPath = $NewFolderPath + '/UnDataSet'
+                
+    $newRSDSName = "DataSource"
+    $newRSDSExtension = "SQL"
+    $newRSDSConnectionString = "Initial Catalog=DB; Data Source=Instance"
+    $newRSDSCredentialRetrieval = "Store"
+    #Dummy credentials
+    $Pass = ConvertTo-SecureString -String "123" -AsPlainText -Force
+    $newRSDSCredential = New-Object -TypeName System.Management.Automation.PSCredential -ArgumentList "sql", $Pass
+    $null = New-RsDataSource -RsFolder $NewFolderPath -Name $newRSDSName -Extension $newRSDSExtension -ConnectionString $newRSDSConnectionString -CredentialRetrieval $newRSDSCredentialRetrieval -DatasourceCredentials $newRSDSCredential
+
+    $DataSourcePath = "$NewFolderPath/$newRSDSName"
+
+    $RsDataSet = Get-RsItemReference -Path $report.Path | Where-Object ReferenceType -eq 'DataSet'
+    $RsDataSource = Get-RsItemReference -Path $report.Path | Where-Object ReferenceType -eq 'DataSource'
+    $RsDataSetSource = Get-RsItemReference -Path $DataSetPath | Where-Object ReferenceType -eq 'DataSource'
+
+    #Set data source and data set for all objects
+    $null = Set-RsDataSourceReference -Path $DataSetPath -DataSourceName $RsDataSetSource.Name -DataSourcePath $DataSourcePath
+    $null = Set-RsDataSourceReference -Path $report.Path -DataSourceName $RsDataSource.Name -DataSourcePath $DataSourcePath
+    $null = Set-RsDataSetReference -Path $report.Path -DataSetName $RsDataSet.Name -DataSetPath $dataSet.Path
+
+    return $report
+}
+
+Describe "Update-RsSubscription" {
+        Context "Update-RsSubscription piped from get-subscription with Owner parameter"{
+                $folderName = 'SutGetRsItemReference_MinParameters' + [guid]::NewGuid()
+                $null = New-RsFolder -Path / -FolderName $folderName
+                $folderPath = '/' + $folderName
+
+                $newReport = Set-FolderReportDataSource($folderPath)
+                
+                Grant-RsSystemRole -Identity 'LOCAL' -RoleName 'System User'
+                 
+                $subscription = Get-NewFileShareSubscription
+
+                Set-RsSubscription -Subscription $subscription -Path $newReport.Path
+                
+                Grant-RsCatalogItemRole -Identity 'LOCAL' -RoleName 'Browser' -path $newReport.path
+                
+                Get-RsSubscription -Path $newReport.Path | Update-RsSubscription -Owner "LOCAL"
+
+                $reportSubscriptions =  Get-RsSubscription -Path $newReport.Path
+
+                [xml]$XMLMatch = $reportSubscriptions.MatchData
+
+                It "Should set a subscription" {
+                   @($reportSubscriptions).Count | Should Be 1
+                   $reportSubscriptions.Report | Should Be "emptyReport"
+                   $reportSubscriptions.EventType | Should Be "TimedSubscription"
+                   $reportSubscriptions.IsDataDriven | Should Be $false
+                   $reportSubscriptions.Owner | Should be "\LOCAL"
+                }
+                Remove-RsCatalogItem -RsFolder $folderPath
+                Revoke-RsSystemAccess -Identity 'local'
+        }
+
+        Context "Update-RsSubscription piped from get-subscription with StartDateTime parameter"{
+                $folderName = 'SutGetRsItemReference_MinParameters' + [guid]::NewGuid()
+                $null = New-RsFolder -Path / -FolderName $folderName
+                $folderPath = '/' + $folderName
+
+                $newReport = Set-FolderReportDataSource($folderPath)
+
+                $subscription = Get-NewFileShareSubscription
+
+                Set-RsSubscription -Subscription $subscription -Path $newReport.Path
+                
+                Get-RsSubscription -Path $newReport.Path | Update-RsSubscription -StartDateTime "1/1/1999 6AM"
+
+                $reportSubscriptions =  Get-RsSubscription -Path $newReport.Path
+
+                [xml]$XMLMatch = $reportSubscriptions.MatchData
+
+                It "Should set a subscription" {
+                   @($reportSubscriptions).Count | Should Be 1
+                   $reportSubscriptions.Report | Should Be "emptyReport"
+                   $reportSubscriptions.EventType | Should Be "TimedSubscription"
+                   $reportSubscriptions.IsDataDriven | Should Be $false
+                   $XMLMatch.ScheduleDefinition.StartDateTime.InnerText | Should be "1999-01-01T06:00:00.000-05:00"
+                }
+                Remove-RsCatalogItem -RsFolder $folderPath
+        }
+        
+        Context "Update-RsSubscription piped from get-subscription with EndDate parameter with poxy"{
+                $folderName = 'SutGetRsItemReference_MinParameters' + [guid]::NewGuid()
+                $null = New-RsFolder -Path / -FolderName $folderName
+                $folderPath = '/' + $folderName
+
+                $proxy = New-RsWebServiceProxy
+
+                $newReport = Set-FolderReportDataSource($folderPath)
+
+                $subscription = Get-NewFileShareSubscription
+                
+                Set-RsSubscription -Subscription $subscription -Path $newReport.Path -Proxy $proxy
+
+                
+                Get-RsSubscription -Path $newReport.Path | Update-RsSubscription -EndDate 1/1/2999
+                
+                $reportSubscriptions = Get-RsSubscription -Path $newReport.Path
+
+                 [xml]$XMLMatch = $reportSubscriptions.MatchData
+
+                It "Should set a subscription" {
+                   @($reportSubscriptions).Count | Should Be 1
+                   $reportSubscriptions.Report | Should Be "emptyReport"
+                   $reportSubscriptions.EventType | Should Be "TimedSubscription"
+                   $reportSubscriptions.IsDataDriven | Should Be $false
+                   $XMLMatch.ScheduleDefinition.EndDate.InnerText | Should Be "2999-01-01"
+                }
+                Remove-RsCatalogItem -RsFolder $folderPath
+        }
+
+        Context "Update-RsSubscription piped from get-subscription with StartDateTime and EndDate Paramter with ReportServerURI"{
+                $folderName = 'SutGetRsItemReference_MinParameters' + [guid]::NewGuid()
+                $null = New-RsFolder -Path / -FolderName $folderName
+                $folderPath = '/' + $folderName
+                
+                $reportServerUri = 'http://localhost/reportserver'
+        
+                $newReport = Set-FolderReportDataSource($folderPath)
+
+                $subscription = Get-NewFileShareSubscription
+                
+                Set-RsSubscription -ReportServerUri $ReportServerUri -Subscription $subscription -Path $newReport.Path
+                
+                Get-RsSubscription -Path $newReport.Path | Update-RsSubscription -StartDateTime "1/1/2000 2PM" -EndDate 2/1/2999
+                
+                $reportSubscriptions = Get-RsSubscription -Path $newReport.Path
+
+                [xml]$XMLMatch = $reportSubscriptions.MatchData
+
+                It "Should set a subscription" {
+                   @($reportSubscriptions).Count | Should Be 1
+                   $reportSubscriptions.Report | Should Be "emptyReport"
+                   $reportSubscriptions.EventType | Should Be "TimedSubscription"
+                   $reportSubscriptions.IsDataDriven | Should Be $false
+                   $XMLMatch.ScheduleDefinition.StartDateTime.InnerText | Should be "2000-01-01T14:00:00.000-05:00"
+                   $XMLMatch.ScheduleDefinition.EndDate.InnerText | Should Be "2999-02-01"
+                }
+                Remove-RsCatalogItem -RsFolder $folderPath
+        }
+
+        
+}


### PR DESCRIPTION
Fixes # 66.

Changes proposed in this pull request:
 - Add cmdlet Update-RsSubscription to edit subscripton startdatetime, endate or owner piped from existing Get-RsSubscription cmdlet

How to test this code:
 - Pester test included Update-RsSubscription.tests.ps1
 - Manual Update existing subscription on local SSRS: Get-RsSubscription -path '/Finance/ImportantReports' | Update-RsSubscription -EndDate 9/9/2099
 
Has been tested on (remove any that don't apply):
 - Powershell 3 and above
 - Windows 7 and above
 - SQL Server 2012 and above
