### PR TITLE
Validating url specified to New-RsRestSession is url to Report Portal

### DIFF
--- a/Tests/Utilities/NewRsRestSessionTests.ps1
+++ b/Tests/Utilities/NewRsRestSessionTests.ps1
@@ -18,10 +18,14 @@ Describe "New-RsRestSession" {
         }
 
         It "Should work for explicit Url" {
-            $session = New-RsRestSession -ReportPortalUrl 'http://localhost/reports' -Verbose
+            $session = New-RsRestSession -ReportPortalUri 'http://localhost/reports' -Verbose
             $session | Should Not BeNullOrEmpty
             $session.Headers | Should Not BeNullOrEmpty
             $session.Headers['X-XSRF-TOKEN'] | Should Not BeNullOrEmpty
+        }
+
+        It "Shouldn't work when incorrect Url is specified" {
+            { New-RsRestSession -ReportPortalUri 'http://localhost/reportserver' -Verbose } | Should Throw "Invalid Report Portal Uri specified! Please make sure ReportPortalUri is the URL to the Report Portal!"
         }
     }
 }


### PR DESCRIPTION
Changes proposed in this pull request:
 - When creating a new Rest Session, we will now validate if the user had provided a valid URL to Report Portal

How to test this code:
 - Added tests to test this code.

Has been tested on (remove any that don't apply):
 - Powershell 3 and above
 - Windows 10 and above
 - SQL Server 2016 and above
