### PR TITLE
Add ExcludeLink and Priority as Email options

### DIFF
--- a/ReportingServicesTools/Functions/CatalogItems/New-RsSubscription.ps1
+++ b/ReportingServicesTools/Functions/CatalogItems/New-RsSubscription.ps1
@@ -62,7 +62,7 @@ function New-RsSubscription {
         .PARAMETER ExcludeLink
             Use with -Destination 'Email' to exclude a link back to the report from the email.
         
-        .PARAMTER Priority
+        .PARAMETER Priority
             Use with -Destination 'Email' to set the priority with which the e-mail message is sent. Valid values are LOW, NORMAL, and HIGH. The default value is NORMAL.
             
         .EXAMPLE
@@ -70,7 +70,7 @@ function New-RsSubscription {
 
             Description
             -----------
-            This command will establish a connection to the Report Server located at http://localhost/ReportServer_sql14 using current user's credentials and create a subscription for report '/path/to/my/Report'
+            This command will establish a connection to the Report Server located at http://localhost/ReportServer using current user's credentials and create a subscription for report '/path/to/my/Report'
             that outputs the report in PDF format to the specified file share path and name on a daily basis at the current time.
 
         .EXAMPLE
@@ -78,8 +78,16 @@ function New-RsSubscription {
 
             Description
             -----------
-            This command will establish a connection to the Report Server located at http://localhost/ReportServer_sql14 using current user's credentials and create a subscription for report '/path/to/my/Report'
+            This command will establish a connection to the Report Server located at http://localhost/ReportServer using current user's credentials and create a subscription for report '/path/to/my/Report'
             that outputs the report in Word format by email to the specified recipient every other Saturday at the current time.
+        
+        .EXAMPLE
+            New-RsSubscription -ReportServerUri 'http://localhost/ReportServer' -Path '/path/to/my/Report' -Description "One minute from now" -Destination 'Email' -Schedule (New-RsScheduleXML -Once -StartDate [datetime]::Now.AddMinutes(1)) -Subject 'One minute from now' -To 'Christopher.Wren@example.com' -RenderFormat 'MHTML' -Priority 'HIGH' -ExcludeLink
+            
+            Description
+            -----------
+            This command will establish a connection to the Report Server located at http://localhost/ReportServer using current user's credentials and create a subscription for report '/path/to/my/Report'
+            that outputs the report in MHTML format by email to the specified recipient one minute from now, with HIGH priority and without a link back to the report
     #>
     
     [cmdletbinding(SupportsShouldProcess = $true, ConfirmImpact = 'Medium',DefaultParameterSetName='FileShare')]

--- a/ReportingServicesTools/Functions/CatalogItems/New-RsSubscription.ps1
+++ b/ReportingServicesTools/Functions/CatalogItems/New-RsSubscription.ps1
@@ -59,6 +59,12 @@ function New-RsSubscription {
         .PARAMETER RenderFormat
             Specify the output format of the report. Must be one of 'PDF','MHTML','IMAGE','CSV','XML','EXCELOPENXML','ATOM','PPTX','WORDOPENXML'
         
+        .PARAMETER ExcludeLink
+            Use with -Destination 'Email' to exclude a link back to the report from the email.
+        
+        .PARAMTER Priority
+            Use with -Destination 'Email' to set the priority with which the e-mail message is sent. Valid values are LOW, NORMAL, and HIGH. The default value is NORMAL.
+            
         .EXAMPLE
             New-RsSubscription -ReportServerUri 'http://localhost/ReportServer' -Path '/path/to/my/Report' -Description 'Daily to folder' -Destination 'FileShare' -Schedule (New-RsScheduleXML -Daily 1) -DestinationPath '\\Myserver\folder' -FileName 'MyReport' -RenderFormat 'PDF'
 
@@ -138,7 +144,16 @@ function New-RsSubscription {
         [Parameter(Mandatory=$True)]
         [ValidateSet('PDF','MHTML','IMAGE','CSV','XML','EXCELOPENXML','ATOM','PPTX','WORDOPENXML')]
         [string]
-        $RenderFormat = 'PDF'
+        $RenderFormat = 'PDF',
+        
+        [Parameter(ParameterSetName='Email')]
+        [switch]
+        $ExcludeLink,
+
+        [Parameter(ParameterSetName='Email')]
+        [ValidateSet('LOW', 'NORMAL', 'HIGH')]
+        [string]
+        $Priority = 'NORMAL'
     )
 
     Begin {
@@ -180,8 +195,10 @@ function New-RsSubscription {
                         CC = $CC
                         BCC = $BCC
                         IncludeReport = (-not $ExcludeReport)
+                        IncludeLink = (-not $ExcludeLink)
                         Subject = $Subject
                         RenderFormat = $RenderFormat
+                        Priority = $Priority
                     }
                 }
                 'FileShare' {


### PR DESCRIPTION
Fixes #85.

Changes proposed in this pull request:
 - Add ExcludeLink and Priority as valid Email parameters
 - Enforce valid set of Priorty options
 - Enforce default value of NORMAL for Priority

How to test this code:
 - I'm open to suggestions

Has been tested on (remove any that don't apply):
 - Powershell 5 and above
 - Windows 10 and above
 - SQL Server 2016 and above
