### PR TITLE
Fix for verbose logging ReportServerUri when creating proxy

### DIFF
--- a/ReportingServicesTools/Functions/Utilities/New-RsWebServiceProxy.ps1
+++ b/ReportingServicesTools/Functions/Utilities/New-RsWebServiceProxy.ps1
@@ -99,6 +99,7 @@ function New-RsWebServiceProxy
     # creating proxy either using specified credentials or default credentials
     try
     {
+        Write-Verbose "Establishing proxy connection to $ReportServerUri..."
         if ($Credential)
         {
             New-WebServiceProxy -Uri $ReportServerUri -Credential $Credential -ErrorAction Stop


### PR DESCRIPTION
Fixes #88.

Changes proposed in this pull request:
 - Verbose logs the Report Server Uri when the Web Service Proxy is being created

How to test this code:
 - No test added as there was no functional change to any of the scripts.

Has been tested on (remove any that don't apply):
 - Powershell 3 and above
 - Windows 7 and above
 - SQL Server 2012 and above
