### PR TITLE
Adding support for migrating KPI across servers

### DIFF
--- a/ReportingServicesTools/Functions/CatalogItems/Remove-RsCatalogItem.ps1
+++ b/ReportingServicesTools/Functions/CatalogItems/Remove-RsCatalogItem.ps1
@@ -10,7 +10,7 @@ function Remove-RsCatalogItem
         .DESCRIPTION
             This function removes an item from the Report Server Catalog.
         
-        .PARAMETER RsFolder
+        .PARAMETER RsItem
             Specify the path of the catalog item to remove.
     
         .PARAMETER ReportServerUri
@@ -27,7 +27,7 @@ function Remove-RsCatalogItem
             Useful when repeatedly having to connect to multiple different Report Server.
         
         .EXAMPLE
-            Remove-RsCatalogItem -ReportServerUri http://localhost/ReportServer -RsFolder /monthlyreports
+            Remove-RsCatalogItem -ReportServerUri http://localhost/ReportServer -RsItem /monthlyreports
    
             Description
             -----------
@@ -45,18 +45,18 @@ function Remove-RsCatalogItem
 
     [CmdletBinding(SupportsShouldProcess = $true, ConfirmImpact = 'Medium')]
     param (
-        [Alias('ItemPath', 'Path')]
+        [Alias('ItemPath', 'Path', 'RsFolder')]
         [Parameter(Mandatory = $True, ValueFromPipeline = $true)]
         [ System.Object[] ]
-        $RsFolder,
-        
+        $RsItem,
+
         [string]
         $ReportServerUri,
-        
+
         [Alias('ReportServerCredentials')]
         [System.Management.Automation.PSCredential]
         $Credential,
-        
+
         $Proxy
     )
     
@@ -67,7 +67,7 @@ function Remove-RsCatalogItem
     
     Process
     {
-        foreach ($item in $RsFolder)
+        foreach ($item in $RsItem)
         {
             if ($PSCmdlet.ShouldProcess($item, "Delete the catalog item"))
             {

--- a/ReportingServicesTools/Functions/CatalogItems/Rest/Out-RsRestCatalogItem.ps1
+++ b/ReportingServicesTools/Functions/CatalogItems/Rest/Out-RsRestCatalogItem.ps1
@@ -6,16 +6,16 @@ function Out-RsRestCatalogItem
     <#
         .SYNOPSIS
             This command downloads catalog items from a report server to disk (using REST endpoint).
-        
+
         .DESCRIPTION
             This command downloads catalog items from a report server to disk (using REST endpoint).
-        
+
         .PARAMETER RsItem
             Path to catalog item to download.
-        
+
         .PARAMETER Destination
             Folder to download catalog item to.
-        
+
         .PARAMETER ApiVersion
             Specify the version of REST Endpoint to use. Valid values are: "v1.0", "v2.0".
             NOTE:
@@ -24,7 +24,7 @@ function Out-RsRestCatalogItem
 
         .PARAMETER ReportPortalUri
             Specify the Report Portal URL to your SQL Server Reporting Services Instance.
-        
+
         .PARAMETER Credential
             Specify the credentials to use when connecting to the Report Server.
 

--- a/ReportingServicesTools/Functions/CatalogItems/Rest/Out-RsRestCatalogItemId.ps1
+++ b/ReportingServicesTools/Functions/CatalogItems/Rest/Out-RsRestCatalogItemId.ps1
@@ -6,13 +6,13 @@ function Out-RsRestCatalogItemId
     <#
         .SYNOPSIS
             This is a helper function that helps download and write catalog item to disk (using REST endpoint).
-        
+
         .DESCRIPTION
             This is a helper function that helps download and write catalog item to disk (using REST endpoint).
-        
+
         .PARAMETER RsItemInfo
             OData Catalog Item object returned from REST endpoint
-        
+
         .PARAMETER Destination
             Folder to download catalog item to.
 
@@ -111,6 +111,15 @@ function Out-RsRestCatalogItemId
         if ((Test-Path $destinationFilePath) -And !$Overwrite)
         {
             throw "An item with same name already exists at destination!"
+        }
+
+        if ($RsItemInfo.Type -eq 'Kpi')
+        {
+            $itemContent = $RsItemInfo | Select-Object -Property Data, Description, DrillthroughTarget, Hidden, IsFavorite, Name, "@odata.Type", Path, Type, ValueFormat, Values, Visualization
+            Write-Verbose "Writing content to $destinationFilePath..."
+            [System.IO.File]::WriteAllText($destinationFilePath, (ConvertTo-Json $itemContent))
+            Write-Verbose "$($RsItemInfo.Path) was downloaded to $destinationFilePath successfully!"
+            return
         }
 
         try

--- a/ReportingServicesTools/Functions/CatalogItems/Rest/Write-RsRestCatalogItem.ps1
+++ b/ReportingServicesTools/Functions/CatalogItems/Rest/Write-RsRestCatalogItem.ps1
@@ -134,18 +134,7 @@ function Write-RsRestCatalogItem
             }
 
             Write-Verbose "Reading file content..."
-            if ($itemType -ne 'DataSource')
-            {
-                $bytes = [System.IO.File]::ReadAllBytes($EntirePath)
-                $payload = @{
-                    "@odata.type" = "#Model.$itemType";
-                    "Content" = [System.Convert]::ToBase64String($bytes);
-                    "ContentType"="";
-                    "Name" = $itemName;
-                    "Path" = $itemPath;
-                }
-            }
-            else
+            if ($itemType -eq 'DataSource')
             {
                 [xml] $dataSourceXml = Get-Content -Path $EntirePath
                 if ($item.Extension -eq '.rsds')
@@ -214,6 +203,23 @@ function Write-RsRestCatalogItem
                         "DisplayText" = $prompt;
                         "UseAsWindowsCredentials" = $true;
                     }
+                }
+            }
+            elseif ($itemType -eq "Kpi")
+            {
+                $content = [System.IO.File]::ReadAllText($EntirePath)
+                $payload = ConvertFrom-Json $content
+                $payload.Path = $itemPath
+            }
+            else
+            {
+                $bytes = [System.IO.File]::ReadAllBytes($EntirePath)
+                $payload = @{
+                    "@odata.type" = "#Model.$itemType";
+                    "Content" = [System.Convert]::ToBase64String($bytes);
+                    "ContentType"="";
+                    "Name" = $itemName;
+                    "Path" = $itemPath;
                 }
             }
 

--- a/ReportingServicesTools/Functions/Common/Get-FileExtension.ps1
+++ b/ReportingServicesTools/Functions/Common/Get-FileExtension.ps1
@@ -13,6 +13,7 @@
         'PowerBIReport' { return '.pbix' }
         'ExcelWorkbook' { return '' }
         'Resource' { return '' }
+        'Kpi' { return '.kpi' }
         default      { throw 'Unsupported item type! We only support items which are of type Report, DataSet, DataSource, Mobile Report or Power BI Report' }
     }
 }

--- a/ReportingServicesTools/Functions/Common/Get-ItemType.ps1
+++ b/ReportingServicesTools/Functions/Common/Get-ItemType.ps1
@@ -14,6 +14,7 @@
         '.pbix' { return 'PowerBIReport' }
         '.xls' { return 'ExcelWorkbook' }
         '.xlsx' { return 'ExcelWorkbook' }
+        '.kpi' { return 'Kpi' }
         default { return 'Resource' }
     }
 }

--- a/Tests/CatalogItems/Rest/New-RsRestFolder.Tests.ps1
+++ b/Tests/CatalogItems/Rest/New-RsRestFolder.Tests.ps1
@@ -1,8 +1,8 @@
 # Copyright (c) 2016 Microsoft Corporation. All Rights Reserved.
 # Licensed under the MIT License (MIT)
 
-$reportPortalUri = 'http://localhost/reports'
-$reportServerUri = 'http://localhost/reportserver'
+$reportPortalUri = if ($env:PesterPortalUrl -eq $null) { 'http://localhost/reports' } else { $env:PesterPortalUrl }
+$reportServerUri = if ($env:PesterServerUrl -eq $null) { 'http://localhost/reportserver' } else { $env:PesterServerUrl }
 
 function VerifyCatalogItemExists()
 {

--- a/Tests/CatalogItems/Rest/Out-RsRestCatalogItem.Tests.ps1
+++ b/Tests/CatalogItems/Rest/Out-RsRestCatalogItem.Tests.ps1
@@ -1,8 +1,8 @@
 # Copyright (c) 2016 Microsoft Corporation. All Rights Reserved.
 # Licensed under the MIT License (MIT)
 
-$reportPortalUri = 'http://localhost/reports'
-$reportServerUri = 'http://localhost/reportserver'
+$reportPortalUri = if ($env:PesterPortalUrl -eq $null) { 'http://localhost/reports' } else { $env:PesterPortalUrl }
+$reportServerUri = if ($env:PesterServerUrl -eq $null) { 'http://localhost/reportserver' } else { $env:PesterServerUrl }
 
 function VerifyFileWasDownloaded()
 {
@@ -77,6 +77,30 @@ Describe "Out-RsRestCatalogItem" {
             Out-RsRestCatalogItem -ReportPortalUri $reportPortalUri -RsItem $itemPath -Destination $localFolderPath -Verbose
             VerifyFileWasDownloaded -folderPath $localFolderPath -fileName 'SimplePowerBIReport.pbix'
         }
+
+        It "Should download a XLS file" {
+            $itemPath = Join-Path -Path $rsFolderPath -ChildPath 'OldExcelWorkbook.xls'
+            Out-RsRestCatalogItem -ReportPortalUri $reportPortalUri -RsItem $itemPath -Destination $localFolderPath -Verbose
+            VerifyFileWasDownloaded -folderPath $localFolderPath -fileName 'OldExcelWorkbook.xls'
+        }
+
+        It "Should download a XLSX file" {
+            $itemPath = Join-Path -Path $rsFolderPath -ChildPath 'NewExcelWorkbook.xlsx'
+            Out-RsRestCatalogItem -ReportPortalUri $reportPortalUri -RsItem $itemPath -Destination $localFolderPath -Verbose
+            VerifyFileWasDownloaded -folderPath $localFolderPath -fileName 'NewExcelWorkbook.xlsx'
+        }
+
+        It "Should download a Resource file" {
+            $itemPath = Join-Path -Path $rsFolderPath -ChildPath emptyFile.txt
+            Out-RsRestCatalogItem -ReportPortalUri $reportPortalUri -RsItem $itemPath -Destination $localFolderPath -Verbose
+            VerifyFileWasDownloaded -folderPath $localFolderPath -fileName 'emptyFile.txt'
+        }
+
+        It "Should download a KPI" {
+            $itemPath = Join-Path -Path $rsFolderPath -ChildPath NewKPI
+            Out-RsRestCatalogItem -ReportPortalUri $reportPortalUri -RsItem $itemPath -Destination $localFolderPath -Verbose
+            VerifyFileWasDownloaded -folderPath $localFolderPath -fileName 'NewKPI.kpi'
+        }
     }
 
     Context "WebSession parameter" {
@@ -114,6 +138,30 @@ Describe "Out-RsRestCatalogItem" {
             $itemPath = Join-Path -Path $rsFolderPath -ChildPath SimplePowerBIReport
             Out-RsRestCatalogItem -WebSession $webSession -RsItem $itemPath -Destination $localFolderPath -Verbose
             VerifyFileWasDownloaded -folderPath $localFolderPath -fileName 'SimplePowerBIReport.pbix'
+        }
+
+        It "Should download a XLS file" {
+            $itemPath = Join-Path -Path $rsFolderPath -ChildPath 'OldExcelWorkbook.xls'
+            Out-RsRestCatalogItem -ReportPortalUri $reportPortalUri -RsItem $itemPath -Destination $localFolderPath -Verbose
+            VerifyFileWasDownloaded -folderPath $localFolderPath -fileName 'OldExcelWorkbook.xls'
+        }
+
+        It "Should download a XLSX file" {
+            $itemPath = Join-Path -Path $rsFolderPath -ChildPath 'NewExcelWorkbook.xlsx'
+            Out-RsRestCatalogItem -ReportPortalUri $reportPortalUri -RsItem $itemPath -Destination $localFolderPath -Verbose
+            VerifyFileWasDownloaded -folderPath $localFolderPath -fileName 'NewExcelWorkbook.xlsx'
+        }
+
+        It "Should download a Resource file" {
+            $itemPath = Join-Path -Path $rsFolderPath -ChildPath emptyFile.txt
+            Out-RsRestCatalogItem -ReportPortalUri $reportPortalUri -RsItem $itemPath -Destination $localFolderPath -Verbose
+            VerifyFileWasDownloaded -folderPath $localFolderPath -fileName 'emptyFile.txt'
+        }
+
+        It "Should download a KPI" {
+            $itemPath = Join-Path -Path $rsFolderPath -ChildPath NewKPI
+            Out-RsRestCatalogItem -ReportPortalUri $reportPortalUri -RsItem $itemPath -Destination $localFolderPath -Verbose
+            VerifyFileWasDownloaded -folderPath $localFolderPath -fileName 'NewKPI.kpi'
         }
     }
 }

--- a/Tests/CatalogItems/Rest/Out-RsRestFolderContent.Tests.ps1
+++ b/Tests/CatalogItems/Rest/Out-RsRestFolderContent.Tests.ps1
@@ -1,8 +1,8 @@
 # Copyright (c) 2016 Microsoft Corporation. All Rights Reserved.
 # Licensed under the MIT License (MIT)
 
-$reportPortalUri = 'http://localhost/reports'
-$reportServerUri = 'http://localhost/reportserver'
+$reportPortalUri = if ($env:PesterPortalUrl -eq $null) { 'http://localhost/reports' } else { $env:PesterPortalUrl }
+$reportServerUri = if ($env:PesterServerUrl -eq $null) { 'http://localhost/reportserver' } else { $env:PesterServerUrl }
 
 function VerifyFileWasDownloaded()
 {
@@ -18,8 +18,6 @@ function VerifyFileWasDownloaded()
     # Test if the report was downloaded
     $localReportDownloaded = Get-ChildItem  $folderPath | Where-Object { $_.Name -eq $fileName }
     $localReportDownloaded | Should Not BeNullOrEmpty
-    $localReportDownloadedPath = $folderPath +'\' + $fileName
-    Remove-Item $localReportDownloadedPath
 }
 
 Describe "Out-RsRestFolderContent" {
@@ -27,16 +25,16 @@ Describe "Out-RsRestFolderContent" {
     $destinationPath = ""
 
     BeforeEach {
+        $session = New-RsRestSession -ReportPortalUri $reportPortalUri
+
         # Create a folder on Report Server to upload some files to
         $folderName = 'SUT_OutRsRestCatalogItem_' + [guid]::NewGuid()
         $rsFolderPath = "/$folderName"
-        New-RsRestFolder -ReportPortalUri $reportPortalUri -RsFolder "/" -FolderName $folderName
-        New-RsRestFolder -ReportPortalUri $reportPortalUri -RsFolder $rsFolderPath -FolderName "Folder"
+        New-RsRestFolder -WebSession $session -RsFolder "/" -FolderName $folderName
 
         # Upload the catalog items that are going to be downloaded
         $localResourcesPath =   (Get-Item -Path ".\").FullName  + '\Tests\CatalogItems\testResources'
-        Write-RsRestCatalogItem -ReportPortalUri $reportPortalUri -RsFolder $rsFolderPath -Path "$localResourcesPath\emptyReport.rdl"
-        Write-RsRestCatalogItem -ReportPortalUri $reportPortalUri -RsFolder "$rsFolderPath/Folder" -Path "$localResourcesPath\testResources2\emptyReport2.rdl"
+        Write-RsRestFolderContent -WebSession $session -RsFolder $rsFolderPath -Path $localResourcesPath -Recurse
 
         # Create a local folder to download the catalog items
         $localFolderName = 'SutOutRsRestFolderContentTest' + [guid]::NewGuid()
@@ -47,19 +45,40 @@ Describe "Out-RsRestFolderContent" {
 
     AfterEach {
         Remove-RsCatalogItem -ReportServerUri $reportServerUri -RsFolder $rsFolderPath
-        Remove-Item -Path $destinationPath -Recurse
+        if ($destinationPath -ne $null -and $destinationPath.Length -ne 0 -and (Test-Path $destinationPath))
+        {
+            Remove-Item -Path $destinationPath -Recurse
+        }
     }
 
     Context "ReportPortalUri parameter" {
         It "Downloads all resources from a folder" {
             Out-RsRestFolderContent -ReportPortalUri $reportPortalUri -RsFolder $rsFolderPath -Destination $destinationPath -Verbose
+            VerifyFileWasDownloaded -folderPath $destinationPath -fileName "emptyFile.txt"
             VerifyFileWasDownloaded -folderPath $destinationPath -fileName "emptyReport.rdl"
+            VerifyFileWasDownloaded -folderPath $destinationPath -fileName "NewExcelWorkbook.xlsx"
+            VerifyFileWasDownloaded -folderPath $destinationPath -fileName "NewKPI.kpi"
+            VerifyFileWasDownloaded -folderPath $destinationPath -fileName "OldExcelWorkbook.xls"
+            VerifyFileWasDownloaded -folderPath $destinationPath -fileName "SimpleMobileReport.rsmobile"
+            VerifyFileWasDownloaded -folderPath $destinationPath -fileName "SimplePowerBIReport.pbix"
+            VerifyFileWasDownloaded -folderPath $destinationPath -fileName "SqlPowerBIReport.pbix"
+            VerifyFileWasDownloaded -folderPath $destinationPath -fileName "SutWriteRsFolderContent_DataSource.rsds"
+            VerifyFileWasDownloaded -folderPath $destinationPath -fileName "UnDataset.rsd"
         }
 
         It "Downloads all resources from subfolders of a folder" {
             Out-RsRestFolderContent -ReportPortalUri $reportPortalUri -RsFolder $rsFolderPath -Destination $destinationPath -Recurse -Verbose
+            VerifyFileWasDownloaded -folderPath $destinationPath -fileName "emptyFile.txt"
             VerifyFileWasDownloaded -folderPath $destinationPath -fileName "emptyReport.rdl"
-            VerifyFileWasDownloaded -folderPath "$destinationPath\Folder" -fileName "emptyReport2.rdl"
+            VerifyFileWasDownloaded -folderPath $destinationPath -fileName "NewExcelWorkbook.xlsx"
+            VerifyFileWasDownloaded -folderPath $destinationPath -fileName "NewKPI.kpi"
+            VerifyFileWasDownloaded -folderPath $destinationPath -fileName "OldExcelWorkbook.xls"
+            VerifyFileWasDownloaded -folderPath $destinationPath -fileName "SimpleMobileReport.rsmobile"
+            VerifyFileWasDownloaded -folderPath $destinationPath -fileName "SimplePowerBIReport.pbix"
+            VerifyFileWasDownloaded -folderPath $destinationPath -fileName "SqlPowerBIReport.pbix"
+            VerifyFileWasDownloaded -folderPath $destinationPath -fileName "SutWriteRsFolderContent_DataSource.rsds"
+            VerifyFileWasDownloaded -folderPath $destinationPath -fileName "UnDataset.rsd"
+            VerifyFileWasDownloaded -folderPath "$destinationPath\testResources2" -fileName "emptyReport2.rdl"
         }
     }
 
@@ -72,13 +91,31 @@ Describe "Out-RsRestFolderContent" {
 
         It "Downloads all resources from a folder" {
             Out-RsRestFolderContent -WebSession $webSession -RsFolder $rsFolderPath -Destination $destinationPath -Verbose
+            VerifyFileWasDownloaded -folderPath $destinationPath -fileName "emptyFile.txt"
             VerifyFileWasDownloaded -folderPath $destinationPath -fileName "emptyReport.rdl"
+            VerifyFileWasDownloaded -folderPath $destinationPath -fileName "NewExcelWorkbook.xlsx"
+            VerifyFileWasDownloaded -folderPath $destinationPath -fileName "NewKPI.kpi"
+            VerifyFileWasDownloaded -folderPath $destinationPath -fileName "OldExcelWorkbook.xls"
+            VerifyFileWasDownloaded -folderPath $destinationPath -fileName "SimpleMobileReport.rsmobile"
+            VerifyFileWasDownloaded -folderPath $destinationPath -fileName "SimplePowerBIReport.pbix"
+            VerifyFileWasDownloaded -folderPath $destinationPath -fileName "SqlPowerBIReport.pbix"
+            VerifyFileWasDownloaded -folderPath $destinationPath -fileName "SutWriteRsFolderContent_DataSource.rsds"
+            VerifyFileWasDownloaded -folderPath $destinationPath -fileName "UnDataset.rsd"
         }
 
         It "Downloads all resources from subfolders of a folder" {
             Out-RsRestFolderContent -WebSession $webSession -RsFolder $rsFolderPath -Destination $destinationPath -Recurse -Verbose
+            VerifyFileWasDownloaded -folderPath $destinationPath -fileName "emptyFile.txt"
             VerifyFileWasDownloaded -folderPath $destinationPath -fileName "emptyReport.rdl"
-            VerifyFileWasDownloaded -folderPath "$destinationPath\Folder" -fileName "emptyReport2.rdl"
+            VerifyFileWasDownloaded -folderPath $destinationPath -fileName "NewExcelWorkbook.xlsx"
+            VerifyFileWasDownloaded -folderPath $destinationPath -fileName "NewKPI.kpi"
+            VerifyFileWasDownloaded -folderPath $destinationPath -fileName "OldExcelWorkbook.xls"
+            VerifyFileWasDownloaded -folderPath $destinationPath -fileName "SimpleMobileReport.rsmobile"
+            VerifyFileWasDownloaded -folderPath $destinationPath -fileName "SimplePowerBIReport.pbix"
+            VerifyFileWasDownloaded -folderPath $destinationPath -fileName "SqlPowerBIReport.pbix"
+            VerifyFileWasDownloaded -folderPath $destinationPath -fileName "SutWriteRsFolderContent_DataSource.rsds"
+            VerifyFileWasDownloaded -folderPath $destinationPath -fileName "UnDataset.rsd"
+            VerifyFileWasDownloaded -folderPath "$destinationPath\testResources2" -fileName "emptyReport2.rdl"
         }
     }
 }

--- a/Tests/CatalogItems/Rest/Remove-RsRestCatalogItem.Tests.ps1
+++ b/Tests/CatalogItems/Rest/Remove-RsRestCatalogItem.Tests.ps1
@@ -1,8 +1,8 @@
 # Copyright (c) 2016 Microsoft Corporation. All Rights Reserved.
 # Licensed under the MIT License (MIT)
 
-$reportPortalUri = 'http://localhost/reports'
-$reportServerUri = 'http://localhost/reportserver'
+$reportPortalUri = if ($env:PesterPortalUrl -eq $null) { 'http://localhost/reports' } else { $env:PesterPortalUrl }
+$reportServerUri = if ($env:PesterServerUrl -eq $null) { 'http://localhost/reportserver' } else { $env:PesterServerUrl }
 
 function VerifyCatalogItemDoesNotExists()
 {

--- a/Tests/CatalogItems/Rest/Remove-RsRestFolder.Tests.ps1
+++ b/Tests/CatalogItems/Rest/Remove-RsRestFolder.Tests.ps1
@@ -1,8 +1,8 @@
 # Copyright (c) 2016 Microsoft Corporation. All Rights Reserved.
 # Licensed under the MIT License (MIT)
 
-$reportPortalUri = 'http://localhost/reports'
-$reportServerUri = 'http://localhost/reportserver'
+$reportPortalUri = if ($env:PesterPortalUrl -eq $null) { 'http://localhost/reports' } else { $env:PesterPortalUrl }
+$reportServerUri = if ($env:PesterServerUrl -eq $null) { 'http://localhost/reportserver' } else { $env:PesterServerUrl }
 
 function VerifyCatalogItemDoesNotExists()
 {

--- a/Tests/CatalogItems/Rest/Write-RsRestCatalogItem.Tests.ps1
+++ b/Tests/CatalogItems/Rest/Write-RsRestCatalogItem.Tests.ps1
@@ -1,8 +1,8 @@
 # Copyright (c) 2016 Microsoft Corporation. All Rights Reserved.
 # Licensed under the MIT License (MIT)
 
-$reportPortalUri = 'http://localhost/reports'
-$reportServerUri = 'http://localhost/reportserver'
+$reportPortalUri = if ($env:PesterPortalUrl -eq $null) { 'http://localhost/reports' } else { $env:PesterPortalUrl }
+$reportServerUri = if ($env:PesterServerUrl -eq $null) { 'http://localhost/reportserver' } else { $env:PesterServerUrl }
 
 function VerifyCatalogItemExists()
 {
@@ -89,6 +89,12 @@ Describe "Write-RsRestCatalogItem" {
             Write-RsRestCatalogItem -ReportPortalUri $reportPortalUri -Path $itemPath -RsFolder $rsFolderPath
             VerifyCatalogItemExists -itemName 'emptyFile.txt' -itemType 'Resource' -folderPath $rsFolderPath -reportServerUri $reportServerUri
         }
+
+        It "Should upload a local KPI file" {
+            $itemPath = $localPath + '\NewKPI.kpi'
+            Write-RsRestCatalogItem -ReportPortalUri $reportPortalUri -Path $itemPath -RsFolder $rsFolderPath
+            VerifyCatalogItemExists -itemName 'NewKPI' -itemType 'Kpi' -folderPath $rsFolderPath -reportServerUri $reportServerUri
+        }
     }
 
     Context "WebSession parameter" {
@@ -140,6 +146,12 @@ Describe "Write-RsRestCatalogItem" {
             $itemPath = $localPath + '\emptyFile.txt'
             Write-RsRestCatalogItem -WebSession $webSession -Path $itemPath -RsFolder $rsFolderPath
             VerifyCatalogItemExists -itemName 'emptyFile.txt' -itemType 'Resource' -folderPath $rsFolderPath -reportServerUri $reportServerUri
+        }
+
+        It "Should upload a local KPI file" {
+            $itemPath = $localPath + '\NewKPI.kpi'
+            Write-RsRestCatalogItem -ReportPortalUri $reportPortalUri -Path $itemPath -RsFolder $rsFolderPath
+            VerifyCatalogItemExists -itemName 'NewKPI' -itemType 'Kpi' -folderPath $rsFolderPath -reportServerUri $reportServerUri
         }
     }
 }

--- a/Tests/CatalogItems/Rest/Write-RsRestFolderContent.Tests.ps1
+++ b/Tests/CatalogItems/Rest/Write-RsRestFolderContent.Tests.ps1
@@ -1,8 +1,8 @@
 # Copyright (c) 2016 Microsoft Corporation. All Rights Reserved.
 # Licensed under the MIT License (MIT)
 
-$reportPortalUri = 'http://localhost/reports'
-$reportServerUri = 'http://localhost/reportserver'
+$reportPortalUri = if ($env:PesterPortalUrl -eq $null) { 'http://localhost/reports' } else { $env:PesterPortalUrl }
+$reportServerUri = if ($env:PesterServerUrl -eq $null) { 'http://localhost/reportserver' } else { $env:PesterServerUrl }
 
 function VerifyCatalogItemExists()
 {
@@ -53,6 +53,7 @@ Describe "Write-RsRestFolderContent" {
             VerifyCatalogItemExists -itemName "SqlPowerBIReport" -itemType "PowerBIReport" -folderPath $rsFolderPath -reportServerUri $reportServerUri
             VerifyCatalogItemExists -itemName "SutWriteRsFolderContent_DataSource" -itemType "DataSource" -folderPath $rsFolderPath -reportServerUri $reportServerUri
             VerifyCatalogItemExists -itemName "UnDataset" -itemType "DataSet" -folderPath $rsFolderPath -reportServerUri $reportServerUri
+            VerifyCatalogItemExists -itemName "NewKPI" -itemType "Kpi" -folderPath $rsFolderPath -reportServerUri $reportServerUri
         }
 
         It "Creates subfolders and deploys resources correctly" {
@@ -86,6 +87,7 @@ Describe "Write-RsRestFolderContent" {
             VerifyCatalogItemExists -itemName "SqlPowerBIReport" -itemType "PowerBIReport" -folderPath $rsFolderPath -reportServerUri $reportServerUri
             VerifyCatalogItemExists -itemName "SutWriteRsFolderContent_DataSource" -itemType "DataSource" -folderPath $rsFolderPath -reportServerUri $reportServerUri
             VerifyCatalogItemExists -itemName "UnDataset" -itemType "DataSet" -folderPath $rsFolderPath -reportServerUri $reportServerUri
+            VerifyCatalogItemExists -itemName "NewKPI" -itemType "Kpi" -folderPath $rsFolderPath -reportServerUri $reportServerUri
         }
 
         It "Creates subfolders and deploys resources correctly" {

--- a/Tests/CatalogItems/testResources/NewKPI.kpi
+++ b/Tests/CatalogItems/testResources/NewKPI.kpi
@@ -1,0 +1,45 @@
+{
+    "Data":  {
+                 "Value":  {
+                               "@odata.type":  "#Model.KpiStaticDataItem",
+                               "Type":  "Static",
+                               "Value":  "513120"
+                           },
+                 "Goal":  null,
+                 "Status":  {
+                                "@odata.type":  "#Model.KpiStaticDataItem",
+                                "Type":  "Static",
+                                "Value":  "1"
+                            },
+                 "TrendSet":  {
+                                  "@odata.type":  "#Model.KpiStaticDataItem",
+                                  "Type":  "Static",
+                                  "Value":  "[7.0,6.0,1.0,7.0,2.0,6.0,5.0,9.0]"
+                              }
+             },
+    "Description":  null,
+    "DrillthroughTarget":  null,
+    "Hidden":  false,
+    "IsFavorite":  false,
+    "Name":  "NewKPI",
+	"@odata.type": "#Model.Kpi",
+    "Path":  "/NewKPI",
+    "Type":  "Kpi",
+    "ValueFormat":  "General",
+    "Values":  {
+                   "Value":  "513120",
+                   "Goal":  null,
+                   "Status":  1.0,
+                   "TrendSet":  [
+                                    7.0,
+                                    6.0,
+                                    1.0,
+                                    7.0,
+                                    2.0,
+                                    6.0,
+                                    5.0,
+                                    9.0
+                                ]
+               },
+    "Visualization":  "Bar"
+}

--- a/Tests/CatalogItems/testResources/emptyFile.txt
+++ b/Tests/CatalogItems/testResources/emptyFile.txt
@@ -1,0 +1,1 @@
+hello world


### PR DESCRIPTION
Changes proposed in this pull request:
 - Added support for downloading KPIs
 - Added support for uploading KPIs
 - Made a minor change to one of the parameters in Remove-RsCatalogItem

How to test this code:
 - Tests were added

Has been tested on (remove any that don't apply):
 - Powershell 5
 - Windows 10
 - SQL Server 2017, Power BI Report Server
