### PR TITLE
Pashah/overwrite catalog item

### DIFF
--- a/ReportingServicesTools/Functions/CatalogItems/Rest/Write-RsRestCatalogItem.ps1
+++ b/ReportingServicesTools/Functions/CatalogItems/Rest/Write-RsRestCatalogItem.ps1
@@ -97,7 +97,14 @@ function Write-RsRestCatalogItem
         $WebSession = New-RsRestSessionHelper -BoundParameters $PSBoundParameters
         $ReportPortalUri = Get-RsPortalUriHelper -WebSession $WebSession
         $catalogItemsUri = $ReportPortalUri + "api/$RestApiVersion/CatalogItems"
-        $catalogItemsByPathApi = $ReportPortalUri + "api/$RestApiVersion/CatalogItemByPath(path=@path)?@path=%27{0}%27"
+        if ($RestApiVersion -eq "v1.0")
+        {
+            $catalogItemsByPathApi = $ReportPortalUri + "api/$RestApiVersion/CatalogItemByPath(path=@path)?@path=%27{0}%27"
+        }
+        else
+        {
+            $catalogItemsByPathApi = $ReportPortalUri + "api/$RestApiVersion/CatalogItems(Path='{0}')"
+        }
         $catalogItemsUpdateUri = $ReportPortalUri + "api/$RestApiVersion/CatalogItems({0})"
     }
     Process

--- a/Tests/CatalogItems/Rest/Write-RsRestCatalogItem.Tests.ps1
+++ b/Tests/CatalogItems/Rest/Write-RsRestCatalogItem.Tests.ps1
@@ -33,7 +33,7 @@ Describe "Write-RsRestCatalogItem" {
 
     BeforeEach {
         $folderName = 'SUT_WriteRsRestCatalogItem_' + [guid]::NewGuid()
-        New-RsRestFolder -ReportPortalUri $reportPortalUri -RsFolder / -FolderName $folderName -Verbose
+        New-RsRestFolder -ReportPortalUri $reportPortalUri -RsFolder / -FolderName $folderName
         $rsFolderPath = '/' + $folderName
     }
 
@@ -44,56 +44,69 @@ Describe "Write-RsRestCatalogItem" {
     Context "ReportPortalUri parameter" {
         It "Should upload a local RDL file" {
             $itemPath = Join-Path -Path $localPath -ChildPath emptyReport.rdl
-            Write-RsRestCatalogItem -ReportPortalUri $reportPortalUri -Path $itemPath -RsFolder $rsFolderPath
+            Write-RsRestCatalogItem -ReportPortalUri $reportPortalUri -Path $itemPath -RsFolder $rsFolderPath -Verbose
             VerifyCatalogItemExists -itemName 'emptyReport' -itemType 'Report' -folderPath $rsFolderPath -reportServerUri $reportServerUri
         }
 
         It "Should upload a local RSDS file" {
             $itemPath = $localPath + '\SutWriteRsFolderContent_DataSource.rsds'
-            Write-RsRestCatalogItem -ReportPortalUri $reportPortalUri -Path $itemPath -RsFolder $rsFolderPath
+            Write-RsRestCatalogItem -ReportPortalUri $reportPortalUri -Path $itemPath -RsFolder $rsFolderPath -Verbose
             VerifyCatalogItemExists -itemName 'SutWriteRsFolderContent_DataSource' -itemType 'DataSource' -folderPath $rsFolderPath -reportServerUri $reportServerUri
         }
 
         It "Should upload a local RSD file" {
             $itemPath = $localPath + '\UnDataset.rsd'
-            Write-RsRestCatalogItem -ReportPortalUri $reportPortalUri -Path $itemPath -RsFolder $rsFolderPath
+            Write-RsRestCatalogItem -ReportPortalUri $reportPortalUri -Path $itemPath -RsFolder $rsFolderPath -Verbose
             VerifyCatalogItemExists -itemName 'UnDataset' -itemType 'DataSet' -folderPath $rsFolderPath -reportServerUri $reportServerUri
         }
 
         It "Should upload a local RSMOBILE file" {
             $itemPath = $localPath + '\SimpleMobileReport.rsmobile'
-            Write-RsRestCatalogItem -ReportPortalUri $reportPortalUri -Path $itemPath -RsFolder $rsFolderPath
+            Write-RsRestCatalogItem -ReportPortalUri $reportPortalUri -Path $itemPath -RsFolder $rsFolderPath -Verbose
             VerifyCatalogItemExists -itemName 'SimpleMobileReport' -itemType 'MobileReport' -folderPath $rsFolderPath -reportServerUri $reportServerUri
         }
 
         It "Should upload a local PBIX file" {
             $itemPath = $localPath + '\SimplePowerBIReport.pbix'
-            Write-RsRestCatalogItem -ReportPortalUri $reportPortalUri -Path $itemPath -RsFolder $rsFolderPath
+            Write-RsRestCatalogItem -ReportPortalUri $reportPortalUri -Path $itemPath -RsFolder $rsFolderPath -Verbose
             VerifyCatalogItemExists -itemName 'SimplePowerBIReport' -itemType 'PowerBIReport' -folderPath $rsFolderPath -reportServerUri $reportServerUri
         }
 
         It "Should upload a local XLS file" {
             $itemPath = $localPath + '\OldExcelWorkbook.xls'
-            Write-RsRestCatalogItem -ReportPortalUri $reportPortalUri -Path $itemPath -RsFolder $rsFolderPath
+            Write-RsRestCatalogItem -ReportPortalUri $reportPortalUri -Path $itemPath -RsFolder $rsFolderPath -Verbose
             VerifyCatalogItemExists -itemName 'OldExcelWorkbook.xls' -itemType 'ExcelWorkbook' -folderPath $rsFolderPath -reportServerUri $reportServerUri
         }
 
         It "Should upload a local XLSX file" {
             $itemPath = $localPath + '\NewExcelWorkbook.xlsx'
-            Write-RsRestCatalogItem -ReportPortalUri $reportPortalUri -Path $itemPath -RsFolder $rsFolderPath
+            Write-RsRestCatalogItem -ReportPortalUri $reportPortalUri -Path $itemPath -RsFolder $rsFolderPath -Verbose
             VerifyCatalogItemExists -itemName 'NewExcelWorkbook.xlsx' -itemType 'ExcelWorkbook' -folderPath $rsFolderPath -reportServerUri $reportServerUri
         }
 
         It "Should upload a local TXT file" {
             $itemPath = $localPath + '\emptyFile.txt'
-            Write-RsRestCatalogItem -ReportPortalUri $reportPortalUri -Path $itemPath -RsFolder $rsFolderPath
+            Write-RsRestCatalogItem -ReportPortalUri $reportPortalUri -Path $itemPath -RsFolder $rsFolderPath -Verbose
             VerifyCatalogItemExists -itemName 'emptyFile.txt' -itemType 'Resource' -folderPath $rsFolderPath -reportServerUri $reportServerUri
         }
 
         It "Should upload a local KPI file" {
             $itemPath = $localPath + '\NewKPI.kpi'
-            Write-RsRestCatalogItem -ReportPortalUri $reportPortalUri -Path $itemPath -RsFolder $rsFolderPath
+            Write-RsRestCatalogItem -ReportPortalUri $reportPortalUri -Path $itemPath -RsFolder $rsFolderPath -Verbose
             VerifyCatalogItemExists -itemName 'NewKPI' -itemType 'Kpi' -folderPath $rsFolderPath -reportServerUri $reportServerUri
+        }
+
+        It "Should overwrite a file when -Overwrite is specified" {
+            $itemPath = Join-Path -Path $localPath -ChildPath emptyReport.rdl
+            Write-RsRestCatalogItem -ReportPortalUri $reportPortalUri -Path $itemPath -RsFolder $rsFolderPath
+            Write-RsRestCatalogItem -ReportPortalUri $reportPortalUri -Path $itemPath -RsFolder $rsFolderPath -Overwrite -Verbose
+            VerifyCatalogItemExists -itemName 'emptyReport' -itemType 'Report' -folderPath $rsFolderPath -reportServerUri $reportServerUri
+        }
+
+        It "Should not overwrite a file without -Overwrite parameter" {
+            $itemPath = Join-Path -Path $localPath -ChildPath emptyReport.rdl
+            Write-RsRestCatalogItem -ReportPortalUri $reportPortalUri -Path $itemPath -RsFolder $rsFolderPath
+            { Write-RsRestCatalogItem -ReportPortalUri $reportPortalUri -Path $itemPath -RsFolder $rsFolderPath -Verbose } | Should Throw
         }
     }
 
@@ -102,56 +115,69 @@ Describe "Write-RsRestCatalogItem" {
 
         It "Should upload a local RDL file" {
             $itemPath = Join-Path -Path $localPath -ChildPath emptyReport.rdl
-            Write-RsRestCatalogItem -WebSession $webSession -Path $itemPath -RsFolder $rsFolderPath
+            Write-RsRestCatalogItem -WebSession $webSession -Path $itemPath -RsFolder $rsFolderPath -Verbose
             VerifyCatalogItemExists -itemName 'emptyReport' -itemType 'Report' -folderPath $rsFolderPath -reportServerUri $reportServerUri
         }
 
         It "Should upload a local RSDS file" {
             $itemPath = $localPath + '\SutWriteRsFolderContent_DataSource.rsds'
-            Write-RsRestCatalogItem -WebSession $webSession -Path $itemPath -RsFolder $rsFolderPath
+            Write-RsRestCatalogItem -WebSession $webSession -Path $itemPath -RsFolder $rsFolderPath -Verbose
             VerifyCatalogItemExists -itemName 'SutWriteRsFolderContent_DataSource' -itemType 'DataSource' -folderPath $rsFolderPath -reportServerUri $reportServerUri
         }
 
         It "Should upload a local RSD file" {
             $itemPath = $localPath + '\UnDataset.rsd'
-            Write-RsRestCatalogItem -WebSession $webSession -Path $itemPath -RsFolder $rsFolderPath
+            Write-RsRestCatalogItem -WebSession $webSession -Path $itemPath -RsFolder $rsFolderPath -Verbose
             VerifyCatalogItemExists -itemName 'UnDataset' -itemType 'DataSet' -folderPath $rsFolderPath -reportServerUri $reportServerUri
         }
 
         It "Should upload a local RSMOBILE file" {
             $itemPath = $localPath + '\SimpleMobileReport.rsmobile'
-            Write-RsRestCatalogItem -WebSession $webSession -Path $itemPath -RsFolder $rsFolderPath
+            Write-RsRestCatalogItem -WebSession $webSession -Path $itemPath -RsFolder $rsFolderPath -Verbose
             VerifyCatalogItemExists -itemName 'SimpleMobileReport' -itemType 'MobileReport' -folderPath $rsFolderPath -reportServerUri $reportServerUri
         }
 
         It "Should upload a local PBIX file" {
             $itemPath = $localPath + '\SimplePowerBIReport.pbix'
-            Write-RsRestCatalogItem -WebSession $webSession -Path $itemPath -RsFolder $rsFolderPath
+            Write-RsRestCatalogItem -WebSession $webSession -Path $itemPath -RsFolder $rsFolderPath -Verbose
             VerifyCatalogItemExists -itemName 'SimplePowerBIReport' -itemType 'PowerBIReport' -folderPath $rsFolderPath -reportServerUri $reportServerUri
         }
 
         It "Should upload a local XLS file" {
             $itemPath = $localPath + '\OldExcelWorkbook.xls'
-            Write-RsRestCatalogItem -WebSession $webSession -Path $itemPath -RsFolder $rsFolderPath
+            Write-RsRestCatalogItem -WebSession $webSession -Path $itemPath -RsFolder $rsFolderPath -Verbose
             VerifyCatalogItemExists -itemName 'OldExcelWorkbook.xls' -itemType 'ExcelWorkbook' -folderPath $rsFolderPath -reportServerUri $reportServerUri
         }
 
         It "Should upload a local XLSX file" {
             $itemPath = $localPath + '\NewExcelWorkbook.xlsx'
-            Write-RsRestCatalogItem -WebSession $webSession -Path $itemPath -RsFolder $rsFolderPath
+            Write-RsRestCatalogItem -WebSession $webSession -Path $itemPath -RsFolder $rsFolderPath -Verbose
             VerifyCatalogItemExists -itemName 'NewExcelWorkbook.xlsx' -itemType 'ExcelWorkbook' -folderPath $rsFolderPath -reportServerUri $reportServerUri
         }
 
         It "Should upload a local TXT file" {
             $itemPath = $localPath + '\emptyFile.txt'
-            Write-RsRestCatalogItem -WebSession $webSession -Path $itemPath -RsFolder $rsFolderPath
+            Write-RsRestCatalogItem -WebSession $webSession -Path $itemPath -RsFolder $rsFolderPath -Verbose
             VerifyCatalogItemExists -itemName 'emptyFile.txt' -itemType 'Resource' -folderPath $rsFolderPath -reportServerUri $reportServerUri
         }
 
         It "Should upload a local KPI file" {
             $itemPath = $localPath + '\NewKPI.kpi'
-            Write-RsRestCatalogItem -ReportPortalUri $reportPortalUri -Path $itemPath -RsFolder $rsFolderPath
+            Write-RsRestCatalogItem -WebSession $webSession -Path $itemPath -RsFolder $rsFolderPath  -Verbose
             VerifyCatalogItemExists -itemName 'NewKPI' -itemType 'Kpi' -folderPath $rsFolderPath -reportServerUri $reportServerUri
+        }
+
+        It "Should overwrite a file when -Overwrite is specified" {
+            $itemPath = Join-Path -Path $localPath -ChildPath emptyReport.rdl
+            Write-RsRestCatalogItem -WebSession $webSession -Path $itemPath -RsFolder $rsFolderPath
+            Write-RsRestCatalogItem -WebSession $webSession -Path $itemPath -RsFolder $rsFolderPath -Overwrite -Verbose
+            VerifyCatalogItemExists -itemName 'emptyReport' -itemType 'Report' -folderPath $rsFolderPath -reportServerUri $reportServerUri
+        }
+
+        It "Should not overwrite a file without -Overwrite parameter" {
+            $itemPath = Join-Path -Path $localPath -ChildPath emptyReport.rdl
+            Write-RsRestCatalogItem -WebSession $webSession -Path $itemPath -RsFolder $rsFolderPath
+            { Write-RsRestCatalogItem -WebSession $webSession -Path $itemPath -RsFolder $rsFolderPath -Verbose } | Should Throw
         }
     }
 }


### PR DESCRIPTION
Changes proposed in this pull request:
Users were unable to overwrite items even after specifying -Overwrite switch. This issue is fixed in this PR.


How to test this code:
 - Tests added to cover this scenario.

Has been tested on (remove any that don't apply):
 - Powershell 5
 - Windows 10
 - Power BI Report Server
