### PR TITLE
`Write-RsRestFolderContent` does not pass $Credential and $Overwrite

### DIFF
--- a/ReportingServicesTools/Functions/CatalogItems/Rest/Write-RsRestFolderContent.ps1
+++ b/ReportingServicesTools/Functions/CatalogItems/Rest/Write-RsRestFolderContent.ps1
@@ -16,6 +16,9 @@ function Write-RsRestFolderContent
         .PARAMETER RsFolder
             Folder on reportserver to upload the item to.
 
+        .PARAMETER Overwrite
+            Overwrite the old entry, if an existing catalog item with same name exists at the specified destination.
+
         .PARAMETER ReportPortalUri
             Specify the Report Portal URL to your SQL Server Reporting Services Instance.
 
@@ -33,28 +36,28 @@ function Write-RsRestFolderContent
 
         .EXAMPLE
             Write-RsRestCatalogItem -Path 'c:\reports\monthlyreport.rdl' -RsFolder '/monthlyreports'
-            
+
             Description
             -----------
             Uploads the report 'monthlyreport.rdl' to folder '/monthlyreports' to v1.0 REST Endpoint located at http://localhost/reports/.
 
         .EXAMPLE
             Write-RsRestCatalogItem -Path 'c:\reports\monthlyreport.rdl' -RsFolder '/monthlyreports' -RestApiVersion 'v1.0'
-            
+
             Description
             -----------
             Uploads the report 'monthlyreport.rdl' to folder '/monthlyreports' to v1.0 REST Endpoint located at http://localhost/reports/.
 
         .EXAMPLE
             Write-RsRestCatalogItem -WebSession $mySession -Path 'c:\reports\monthlyreport.rdl' -RsFolder '/monthlyreports'
-            
+
             Description
             -----------
             Uploads the report 'monthlyreport.rdl' to folder '/monthlyreports' to v1.0 REST Endpoint.
 
         .EXAMPLE
             Write-RsRestCatalogItem -ReportPortalUri 'http://myserver/reports' -Path 'c:\reports\monthlyreport.rdl' -RsFolder '/monthlyreports'
-            
+
             Description
             -----------
             Uploads the report 'monthlyreport.rdl' to folder '/monthlyreports' to v1.0 REST Endpoint located at http://myserver/reports.
@@ -71,6 +74,10 @@ function Write-RsRestFolderContent
         [Parameter(Mandatory = $True)]
         [string]
         $RsFolder,
+
+        [Alias('Override')]
+        [switch]
+        $Overwrite,
 
         [string]
         $ReportPortalUri,
@@ -144,7 +151,7 @@ function Write-RsRestFolderContent
                     $parentFolder = $RsFolder + $relativePath
                 }
 
-                Write-RsRestCatalogItem -WebSession $WebSession -RestApiVersion $RestApiVersion -Path $item.FullName -RsFolder $parentFolder
+                Write-RsRestCatalogItem -WebSession $WebSession -RestApiVersion $RestApiVersion -Path $item.FullName -RsFolder $parentFolder -Overwrite:$Overwrite -Credential $Credential
             }
         }
     }

--- a/Tests/CatalogItems/Rest/Write-RsRestFolderContent.Tests.ps1
+++ b/Tests/CatalogItems/Rest/Write-RsRestFolderContent.Tests.ps1
@@ -67,6 +67,12 @@ Describe "Write-RsRestFolderContent" {
 
             { Write-RsRestFolderContent -ReportPortalUri $reportPortalUri -Path $localFolderPath -RsFolder $rsFolderPath -Verbose } | Should Throw
         }
+
+        It "Overwrites exisiting resource if -Overwrite option is specified" {
+            Write-RsRestFolderContent -ReportPortalUri $reportPortalUri -Path $localFolderPath -RsFolder $rsFolderPath
+
+            { Write-RsRestFolderContent -ReportPortalUri $reportPortalUri -Path $localFolderPath -RsFolder $rsFolderPath  -Overwrite -Verbose } | Should Not Throw
+        }
     }
 
     Context "WebSession parameter" {
@@ -100,6 +106,12 @@ Describe "Write-RsRestFolderContent" {
             Write-RsRestFolderContent -ReportPortalUri $reportPortalUri -Path $localFolderPath -RsFolder $rsFolderPath
 
             { Write-RsRestFolderContent -ReportPortalUri $reportPortalUri -Path $localFolderPath -RsFolder $rsFolderPath -Verbose } | Should Throw
+        }
+
+        It "Overwrites exisiting resource, if -Overwrite option is specified" {
+            Write-RsRestFolderContent -ReportPortalUri $reportPortalUri -Path $localFolderPath -RsFolder $rsFolderPath
+
+            { Write-RsRestFolderContent -ReportPortalUri $reportPortalUri -Path $localFolderPath -RsFolder $rsFolderPath -Overwrite -Verbose } | Should Not Throw
         }
     }
 }


### PR DESCRIPTION
Fixes #113 .

Changes proposed in this pull request:
 - Adds `$Overwrite` parameter to `Write-RsRestFolderContent`
 - Passes `$Overwrite` and `$Credential` from `Write-RsRestFolderContent` to `Write-RsRestCatalogItem`

How to test this code:
 - Have not tested, sorry

Has been tested on (remove any that don't apply):
 - Powershell 5.1.16299.15
 - Windows 10
 - Power BI Reporting Server
