### PR TITLE
Added Update-RsSubscription

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,7 @@ The following is a list of commands which are available for you to use once you 
 |Set-RsSubscription|This command adds a retrieved subscription to an existing report. For use with Get-RsSubscription.|
 |Set-RsUrlReservation|This command configures the SQL Server Reporting Services URLs.|
 |Set-PbiRsUrlReservation|This command configures the Power BI Report Server URLs.|
+|Update-RsSubscription|This command updates existing subscriptions piped from Get-RsSubscription|
 |Write-RsCatalogItem|This command uploads a report, a dataset or a data source using the SOAP Endpoint..|
 |Write-RsFolderContent|This uploads all reports, datasets and data sources in a folder.|
 |Write-RsRestCatalogItem|This command uploads a report, a dataset or a mobile report using the REST Endpoint.|

--- a/ReportingServicesTools/Functions/CatalogItems/Update-RsSubscription.ps1
+++ b/ReportingServicesTools/Functions/CatalogItems/Update-RsSubscription.ps1
@@ -1,0 +1,142 @@
+# Copyright (c) 2016 Microsoft Corporation. All Rights Reserved.
+# Licensed under the MIT License (MIT)
+
+
+function Update-RsSubscription
+{
+  <#
+        .SYNOPSIS
+            This script will update subscriptions piped from Get-RsSubscriptions
+
+        .DESCRIPTION
+            This script will take the custom object producted by get-RSSubscription and use the data to update the 
+            matchdata xml to either a new startdatetime, enddate, or owner.
+
+        .PARAMETER ReportServerUri
+            Specify the Report Server URL to your SQL Server Reporting Services Instance.
+            Use the "Connect-RsReportServer" function to set/update a default value.
+
+        .PARAMETER Credential
+            Specify the password to use when connecting to your SQL Server Reporting Services Instance.
+            Use the "Connect-RsReportServer" function to set/update a default value.
+
+        .PARAMETER Proxy
+            Report server proxy to use.
+            Use "New-RsWebServiceProxy" to generate a proxy object for reuse.
+            Useful when repeatedly having to connect to multiple different Report Server.
+
+        .PARAMETER StartDateTime
+            StartDateTime to change Start Date and Time of subscription.
+        
+        .PARAMETER EndDate
+            Used to change the EndDate of subscription. 
+
+        .PARAMETER Owner
+            Used to change the owner of a subscription. 
+            
+          
+        .EXAMPLE
+            Get-RsSubscription -path '/Finance/ImportantReports' | Update-RsSubscription -EndDate 9/9/2099
+
+            Description
+            -----------
+            Update all subscriptions on localhost associated with '/finance/ImportantReports' to have an EndDate of 9/9/2099
+
+        .EXAMPLE
+            Get-RsSubscription -path '/Finance/ImportantReports' | Update-RsSubscription -StartDateTime "1/9/2017 9am"
+
+            Description
+            -----------
+            Update all subscriptions on localhost associated with '/finance/ImportantReports' to have a startdate of 1/9/2017 and time of 9am
+        
+        .EXAMPLE
+            Get-RsSubscription -path '/Finance/ImportantReports' | Update-RsSubscription -Owner "Warren"
+
+            Description
+            -----------
+            Update all subscriptions on localhost associated with '/finance/ImportantReports' to have an owner of "Warren".
+            The user being updated needs to have the correct permissions in order to successfully update the owner.
+        
+    #>
+    
+  [CmdletBinding()]
+  param (
+    [string]
+    $ReportServerUri,
+    
+    [System.Management.Automation.PSCredential]
+    $Credential,
+
+    $Proxy,
+
+    [parameter(Mandatory = $false)]
+    [DateTime]$StartDateTime,
+
+    [parameter(Mandatory = $false)]
+    [DateTime]$EndDate,
+
+    [parameter(Mandatory = $False)]
+    [string]$Owner,
+
+    [Parameter(Mandatory=$true,ValueFromPipeLine)]
+    [PSCustomObject[]]$SubProperties
+        
+  )
+    
+  Begin
+  {
+    $Proxy = New-RsWebServiceProxyHelper -BoundParameters $PSBoundParameters
+    
+  }
+  Process
+  {
+    Write-Verbose "Updating Subscriptions..."
+try
+ {
+   [xml]$XMLMatch = $SubProperties.MatchData
+
+    if ($owner){
+    $proxy.ChangeSubscriptionOwner($SubProperties.subscriptionID,$owner)
+    }
+
+            
+    if ($StartDateTime)
+    {
+        $XMLMatch.ScheduleDefinition.StartDateTime.InnerText = $StartDateTime
+    }
+    
+    if ($EndDate)
+    {
+      #check to see if end date exists as a node
+      $EndExists = $XMLMatch.SelectNodes("//*") | Select-Object name | Where-Object name -eq "EndDate"
+      #if no enddate create child node
+      if ($EndExists -eq $null)
+      {
+        $child = $XMLMatch.CreateElement("EndDate")
+        $child.InnerText = $EndDate
+        
+        $XMLMatch.ScheduleDefinition.AppendChild($child)
+        
+      }
+      else
+      {
+          #if enddate node exists update  
+          $XMLMatch.ScheduleDefinition.EndDate.InnerText = $EndDate         
+      } 
+        
+    }
+    
+    if ($StartDateTime -ne $null -or $EndDate -ne $null)
+    {
+      $null = $Proxy.SetSubscriptionProperties($SubProperties.subscriptionID, $SubProperties.DeliverySettings, $SubProperties.Description, $SubProperties.EventType, $XMLMatch.OuterXml, $SubProperties.Values) 
+      Write-Verbose "subscription $($SubProperties.subscriptionId) for $($SubProperties.report) report successfully updated!"
+    }
+    }
+    Catch
+    {
+     throw (New-Object System.Exception("Exception while updating subscription(s)! $($_.Exception.Message)", $_.Exception))
+    }
+    
+  }
+}
+

--- a/ReportingServicesTools/ReportingServicesTools.psd1
+++ b/ReportingServicesTools/ReportingServicesTools.psd1
@@ -104,6 +104,7 @@
         'Set-RsSubscription',
         'Set-RsUrlReservation',
         'Set-PbiRsUrlReservation',
+        'Update-RsSubscription',
         'Write-RsCatalogItem',
         'Write-RsFolderContent',
         'Write-RsRestCatalogItem',

--- a/Tests/CatalogItems/Update-RsSubscription.Tests.ps1
+++ b/Tests/CatalogItems/Update-RsSubscription.Tests.ps1
@@ -1,0 +1,307 @@
+﻿# Copyright (c) 2016 Microsoft Corporation. All Rights Reserved.
+# Licensed under the MIT License (MIT)
+
+#Not in use right now - need email configuration on the report server
+Function Get-NewSubscription
+{
+
+    [xml]$matchData = '<?xml version="1.0" encoding="utf-16" standalone="yes"?><ScheduleDefinition xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><StartDateTime xmlns="http://schemas.microsoft.com/sqlserver/reporting/2010/03/01/ReportServer">2017-07-14T08:00:00.000+01:00</StartDateTime><WeeklyRecurrence xmlns="http://schemas.microsoft.com/sqlserver/reporting/2010/03/01/ReportServer"><WeeksInterval>1</WeeksInterval><DaysOfWeek><Monday>true</Monday><Tuesday>true</Tuesday><Wednesday>true</Wednesday><Thursday>true</Thursday><Friday>true</Friday></DaysOfWeek></WeeklyRecurrence></ScheduleDefinition>'
+    
+    $proxy = New-RsWebServiceProxy
+    $namespace = $proxy.GetType().NameSpace
+
+    $ExtensionSettingsDataType = "$namespace.ExtensionSettings"
+    $ParameterValueOrFieldReference = "$namespace.ParameterValueOrFieldReference[]"
+    $ParameterValueDataType = "$namespace.ParameterValue"
+
+    #Set ExtensionSettings
+    $ExtensionSettings = New-Object $ExtensionSettingsDataType
+                    
+    $ExtensionSettings.Extension = "Report Server Email"
+
+    #Set ParameterValues
+    $ParameterValues = New-Object $ParameterValueOrFieldReference -ArgumentList 8
+
+    $to = New-Object $ParameterValueDataType
+    $to.Name = "TO";
+    $to.Value = "mail@rstools.com"; 
+    $ParameterValues[0] = $to;
+
+    $replyTo = New-Object $ParameterValueDataType
+    $replyTo.Name = "ReplyTo";
+    $replyTo.Value ="dank@rstools.com";
+    $ParameterValues[1] = $replyTo;
+
+    $includeReport = New-Object $ParameterValueDataType
+    $includeReport.Name = "IncludeReport";
+    $includeReport.Value = "False";
+    $ParameterValues[2] = $includeReport;
+
+    $renderFormat = New-Object $ParameterValueDataType
+    $renderFormat.Name = "RenderFormat";
+    $renderFormat.Value = "MHTML";
+    $ParameterValues[3] = $renderFormat;
+
+    $priority = New-Object $ParameterValueDataType
+    $priority.Name = "Priority";
+    $priority.Value = "NORMAL";
+    $ParameterValues[4] = $priority;
+
+    $subject = New-Object $ParameterValueDataType
+    $subject.Name = "Subject";
+    $subject.Value = "Your sales report";
+    $ParameterValues[5] = $subject;
+
+    $comment = New-Object $ParameterValueDataType
+    $comment.Name = "Comment";
+    $comment.Value = "Here is the link to your report.";
+    $ParameterValues[6] = $comment;
+
+    $includeLink = New-Object $ParameterValueDataType
+    $includeLink.Name = "IncludeLink";
+    $includeLink.Value = "True";
+    $ParameterValues[7] = $includeLink;
+
+    $ExtensionSettings.ParameterValues = $ParameterValues
+
+    $subscription = [pscustomobject]@{
+        DeliverySettings      = $ExtensionSettings
+        Description           = "Send email to mail@rstools.com"
+        EventType             = "TimedSubscription"
+        IsDataDriven          = $false
+	    MatchData             = $matchData.OuterXml
+    }
+    
+    return $subscription
+}
+
+Function Get-NewFileShareSubscription
+{
+
+    [xml]$matchData = '<?xml version="1.0" encoding="utf-16" standalone="yes"?><ScheduleDefinition xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><StartDateTime xmlns="http://schemas.microsoft.com/sqlserver/reporting/2010/03/01/ReportServer">2017-07-14T08:00:00.000+01:00</StartDateTime><WeeklyRecurrence xmlns="http://schemas.microsoft.com/sqlserver/reporting/2010/03/01/ReportServer"><WeeksInterval>1</WeeksInterval><DaysOfWeek><Monday>true</Monday><Tuesday>true</Tuesday><Wednesday>true</Wednesday><Thursday>true</Thursday><Friday>true</Friday></DaysOfWeek></WeeklyRecurrence></ScheduleDefinition>'
+    
+    $proxy = New-RsWebServiceProxy
+    $namespace = $proxy.GetType().NameSpace
+
+    $ExtensionSettingsDataType = "$namespace.ExtensionSettings"
+    $ParameterValueOrFieldReference = "$namespace.ParameterValueOrFieldReference[]"
+    $ParameterValueDataType = "$namespace.ParameterValue"
+
+    #Set ExtensionSettings
+    $ExtensionSettings = New-Object $ExtensionSettingsDataType
+                    
+    $ExtensionSettings.Extension = "Report Server FileShare"
+
+    #Set ParameterValues
+    $ParameterValues = New-Object $ParameterValueOrFieldReference -ArgumentList 7
+
+    $to = New-Object $ParameterValueDataType
+    $to.Name = "PATH";
+    $to.Value = "\\unc\path"; 
+    $ParameterValues[0] = $to;
+
+    $replyTo = New-Object $ParameterValueDataType
+    $replyTo.Name = "FILENAME";
+    $replyTo.Value ="Report";
+    $ParameterValues[1] = $replyTo;
+
+    $includeReport = New-Object $ParameterValueDataType
+    $includeReport.Name = "FILEEXTN";
+    $includeReport.Value = "True";
+    $ParameterValues[2] = $includeReport;
+
+    $renderFormat = New-Object $ParameterValueDataType
+    $renderFormat.Name = "USERNAME";
+    $renderFormat.Value = "user";
+    $ParameterValues[3] = $renderFormat;
+
+    $priority = New-Object $ParameterValueDataType
+    $priority.Name = "RENDER_FORMAT";
+    $priority.Value = "PDF";
+    $ParameterValues[4] = $priority;
+
+    $subject = New-Object $ParameterValueDataType
+    $subject.Name = "WRITEMODE";
+    $subject.Value = "Overwrite";
+    $ParameterValues[5] = $subject;
+
+    $comment = New-Object $ParameterValueDataType
+    $comment.Name = "DEFAULTCREDENTIALS";
+    $comment.Value = "False";
+    $ParameterValues[6] = $comment;
+
+    $ExtensionSettings.ParameterValues = $ParameterValues
+
+    $subscription = [pscustomobject]@{
+        DeliverySettings      = $ExtensionSettings
+        Description           = "Shared on \\unc\path"
+        EventType             = "TimedSubscription"
+        IsDataDriven          = $false
+	    MatchData             = $matchData.OuterXml
+    }
+    
+    return $subscription
+}
+
+Function Set-FolderReportDataSource
+{
+    param (
+        [string]
+        $NewFolderPath
+    )
+    
+    
+    $localResourcesPath =   (Get-Item -Path ".\").FullName  + '\Tests\CatalogItems\testResources\emptyReport.rdl'
+    $null = Write-RsCatalogItem -Path $localResourcesPath -RsFolder $NewFolderPath
+    $report = (Get-RsFolderContent -RsFolder $NewFolderPath )| Where-Object TypeName -eq 'Report'
+
+    $localResourcesPath =   (Get-Item -Path ".\").FullName  + '\Tests\CatalogItems\testResources\UnDataset.rsd'
+    $null = Write-RsCatalogItem -Path $localResourcesPath -RsFolder $NewFolderPath
+    $dataSet = (Get-RsFolderContent -RsFolder $NewFolderPath ) | Where-Object TypeName -eq 'DataSet'
+    $DataSetPath = $NewFolderPath + '/UnDataSet'
+                
+    $newRSDSName = "DataSource"
+    $newRSDSExtension = "SQL"
+    $newRSDSConnectionString = "Initial Catalog=DB; Data Source=Instance"
+    $newRSDSCredentialRetrieval = "Store"
+    #Dummy credentials
+    $Pass = ConvertTo-SecureString -String "123" -AsPlainText -Force
+    $newRSDSCredential = New-Object -TypeName System.Management.Automation.PSCredential -ArgumentList "sql", $Pass
+    $null = New-RsDataSource -RsFolder $NewFolderPath -Name $newRSDSName -Extension $newRSDSExtension -ConnectionString $newRSDSConnectionString -CredentialRetrieval $newRSDSCredentialRetrieval -DatasourceCredentials $newRSDSCredential
+
+    $DataSourcePath = "$NewFolderPath/$newRSDSName"
+
+    $RsDataSet = Get-RsItemReference -Path $report.Path | Where-Object ReferenceType -eq 'DataSet'
+    $RsDataSource = Get-RsItemReference -Path $report.Path | Where-Object ReferenceType -eq 'DataSource'
+    $RsDataSetSource = Get-RsItemReference -Path $DataSetPath | Where-Object ReferenceType -eq 'DataSource'
+
+    #Set data source and data set for all objects
+    $null = Set-RsDataSourceReference -Path $DataSetPath -DataSourceName $RsDataSetSource.Name -DataSourcePath $DataSourcePath
+    $null = Set-RsDataSourceReference -Path $report.Path -DataSourceName $RsDataSource.Name -DataSourcePath $DataSourcePath
+    $null = Set-RsDataSetReference -Path $report.Path -DataSetName $RsDataSet.Name -DataSetPath $dataSet.Path
+
+    return $report
+}
+
+Describe "Update-RsSubscription" {
+        Context "Update-RsSubscription piped from get-subscription with Owner parameter"{
+                $folderName = 'SutGetRsItemReference_MinParameters' + [guid]::NewGuid()
+                $null = New-RsFolder -Path / -FolderName $folderName
+                $folderPath = '/' + $folderName
+
+                $newReport = Set-FolderReportDataSource($folderPath)
+                
+                Grant-RsSystemRole -Identity 'LOCAL' -RoleName 'System User'
+                 
+                $subscription = Get-NewFileShareSubscription
+
+                Set-RsSubscription -Subscription $subscription -Path $newReport.Path
+                
+                Grant-RsCatalogItemRole -Identity 'LOCAL' -RoleName 'Browser' -path $newReport.path
+                
+                Get-RsSubscription -Path $newReport.Path | Update-RsSubscription -Owner "LOCAL"
+
+                $reportSubscriptions =  Get-RsSubscription -Path $newReport.Path
+
+                [xml]$XMLMatch = $reportSubscriptions.MatchData
+
+                It "Should set a subscription" {
+                   @($reportSubscriptions).Count | Should Be 1
+                   $reportSubscriptions.Report | Should Be "emptyReport"
+                   $reportSubscriptions.EventType | Should Be "TimedSubscription"
+                   $reportSubscriptions.IsDataDriven | Should Be $false
+                   $reportSubscriptions.Owner | Should be "\LOCAL"
+                }
+                Remove-RsCatalogItem -RsFolder $folderPath
+                Revoke-RsSystemAccess -Identity 'local'
+        }
+
+        Context "Update-RsSubscription piped from get-subscription with StartDateTime parameter"{
+                $folderName = 'SutGetRsItemReference_MinParameters' + [guid]::NewGuid()
+                $null = New-RsFolder -Path / -FolderName $folderName
+                $folderPath = '/' + $folderName
+
+                $newReport = Set-FolderReportDataSource($folderPath)
+
+                $subscription = Get-NewFileShareSubscription
+
+                Set-RsSubscription -Subscription $subscription -Path $newReport.Path
+                
+                Get-RsSubscription -Path $newReport.Path | Update-RsSubscription -StartDateTime "1/1/1999 6AM"
+
+                $reportSubscriptions =  Get-RsSubscription -Path $newReport.Path
+
+                [xml]$XMLMatch = $reportSubscriptions.MatchData
+
+                It "Should set a subscription" {
+                   @($reportSubscriptions).Count | Should Be 1
+                   $reportSubscriptions.Report | Should Be "emptyReport"
+                   $reportSubscriptions.EventType | Should Be "TimedSubscription"
+                   $reportSubscriptions.IsDataDriven | Should Be $false
+                   $XMLMatch.ScheduleDefinition.StartDateTime.InnerText | Should be "1999-01-01T06:00:00.000-05:00"
+                }
+                Remove-RsCatalogItem -RsFolder $folderPath
+        }
+        
+        Context "Update-RsSubscription piped from get-subscription with EndDate parameter with poxy"{
+                $folderName = 'SutGetRsItemReference_MinParameters' + [guid]::NewGuid()
+                $null = New-RsFolder -Path / -FolderName $folderName
+                $folderPath = '/' + $folderName
+
+                $proxy = New-RsWebServiceProxy
+
+                $newReport = Set-FolderReportDataSource($folderPath)
+
+                $subscription = Get-NewFileShareSubscription
+                
+                Set-RsSubscription -Subscription $subscription -Path $newReport.Path -Proxy $proxy
+
+                
+                Get-RsSubscription -Path $newReport.Path | Update-RsSubscription -EndDate 1/1/2999
+                
+                $reportSubscriptions = Get-RsSubscription -Path $newReport.Path
+
+                 [xml]$XMLMatch = $reportSubscriptions.MatchData
+
+                It "Should set a subscription" {
+                   @($reportSubscriptions).Count | Should Be 1
+                   $reportSubscriptions.Report | Should Be "emptyReport"
+                   $reportSubscriptions.EventType | Should Be "TimedSubscription"
+                   $reportSubscriptions.IsDataDriven | Should Be $false
+                   $XMLMatch.ScheduleDefinition.EndDate.InnerText | Should Be "2999-01-01"
+                }
+                Remove-RsCatalogItem -RsFolder $folderPath
+        }
+
+        Context "Update-RsSubscription piped from get-subscription with StartDateTime and EndDate Paramter with ReportServerURI"{
+                $folderName = 'SutGetRsItemReference_MinParameters' + [guid]::NewGuid()
+                $null = New-RsFolder -Path / -FolderName $folderName
+                $folderPath = '/' + $folderName
+                
+                $reportServerUri = 'http://localhost/reportserver'
+        
+                $newReport = Set-FolderReportDataSource($folderPath)
+
+                $subscription = Get-NewFileShareSubscription
+                
+                Set-RsSubscription -ReportServerUri $ReportServerUri -Subscription $subscription -Path $newReport.Path
+                
+                Get-RsSubscription -Path $newReport.Path | Update-RsSubscription -StartDateTime "1/1/2000 2PM" -EndDate 2/1/2999
+                
+                $reportSubscriptions = Get-RsSubscription -Path $newReport.Path
+
+                [xml]$XMLMatch = $reportSubscriptions.MatchData
+
+                It "Should set a subscription" {
+                   @($reportSubscriptions).Count | Should Be 1
+                   $reportSubscriptions.Report | Should Be "emptyReport"
+                   $reportSubscriptions.EventType | Should Be "TimedSubscription"
+                   $reportSubscriptions.IsDataDriven | Should Be $false
+                   $XMLMatch.ScheduleDefinition.StartDateTime.InnerText | Should be "2000-01-01T14:00:00.000-05:00"
+                   $XMLMatch.ScheduleDefinition.EndDate.InnerText | Should Be "2999-02-01"
+                }
+                Remove-RsCatalogItem -RsFolder $folderPath
+        }
+
+        
+}

--- a/Tests/CatalogItems/Update-RsSubscription.Tests.ps1
+++ b/Tests/CatalogItems/Update-RsSubscription.Tests.ps1
@@ -238,7 +238,7 @@ Describe "Update-RsSubscription" {
                    $reportSubscriptions.Report | Should Be "emptyReport"
                    $reportSubscriptions.EventType | Should Be "TimedSubscription"
                    $reportSubscriptions.IsDataDriven | Should Be $false
-                   $XMLMatch.ScheduleDefinition.StartDateTime.InnerText | Should be "1999-01-01T06:00:00.000-05:00"
+                   $XMLMatch.ScheduleDefinition.StartDateTime.InnerText | Should be "1999-01-01T06:00:00.000+00:00"
                 }
                 Remove-RsCatalogItem -RsFolder $folderPath
         }
@@ -297,7 +297,7 @@ Describe "Update-RsSubscription" {
                    $reportSubscriptions.Report | Should Be "emptyReport"
                    $reportSubscriptions.EventType | Should Be "TimedSubscription"
                    $reportSubscriptions.IsDataDriven | Should Be $false
-                   $XMLMatch.ScheduleDefinition.StartDateTime.InnerText | Should be "2000-01-01T14:00:00.000-05:00"
+                   $XMLMatch.ScheduleDefinition.StartDateTime.InnerText | Should be "2000-01-01T14:00:00.000+00:00"
                    $XMLMatch.ScheduleDefinition.EndDate.InnerText | Should Be "2999-02-01"
                 }
                 Remove-RsCatalogItem -RsFolder $folderPath


### PR DESCRIPTION
Altered readme
Altered PSD1
Added Pester Tests
Added Update-RsSubscription function

Fixes # 66 (add update functions)

Changes proposed in this pull request:
 - Add cmdlet Update-RsSubscription to edit subscripton startdatetime, endate or owner piped from existing Get-RsSubscription cmdlet

How to test this code:
 - Pester test included Update-RsSubscription.tests.ps1
 - Manual Update existing subscription on local SSRS: 
Get-RsSubscription -path '/Finance/ImportantReports' | Update-RsSubscription -EndDate 9/9/2099
 - 

Has been tested on (remove any that don't apply):
 - Powershell 3 and above
 - Windows 7 and above
 - SQL Server 2012 and above
