### PR TITLE
Added a Parent Security property to Get-RsCatalogItemRole

### DIFF
--- a/ReportingServicesTools/Functions/Security/Get-RsCatalogItemRole.ps1
+++ b/ReportingServicesTools/Functions/Security/Get-RsCatalogItemRole.ps1
@@ -101,7 +101,7 @@ function Get-RsCatalogItemRole
 
         $parentType = $Proxy.GetItemType($Path)
 
-        $catalogItemRoles = New-RsCatalogItemRoleObject -Policy $parentPolicy -Path $Path -TypeName $parentType
+        $catalogItemRoles = New-RsCatalogItemRoleObject -Policy $parentPolicy -Path $Path -TypeName $parentType -ParentSecurity $false
 
             
         if($Recurse -and $parentType -eq "Folder") {

--- a/ReportingServicesTools/Functions/Security/Get-RsCatalogItemRole.ps1
+++ b/ReportingServicesTools/Functions/Security/Get-RsCatalogItemRole.ps1
@@ -133,7 +133,7 @@ function Get-RsCatalogItemRole
 
                 foreach($childPolicy in $childPolicies)
                 {
-                    $catalogItemRoles +=  New-RsCatalogItemRoleObject -Policy $childPolicy -Path $item.Path -TypeName $item.TypeName
+                    $catalogItemRoles +=  New-RsCatalogItemRoleObject -Policy $childPolicy -Path $item.Path -TypeName $item.TypeName -ParentSecurity $inheritParent
                 }
 
                 

--- a/ReportingServicesTools/Functions/Utilities/New-RsCatalogItemRoleObject.ps1
+++ b/ReportingServicesTools/Functions/Utilities/New-RsCatalogItemRoleObject.ps1
@@ -19,8 +19,8 @@ function New-RscatalogItemRoleObject
         .PARAMETER TypeName
             Specity the type of the Catalog Item
         
-        .PARAMETER Roles
-            Specify the Roles assigned to the Catalog Item
+        .PARAMETER ParentSecurity
+            Specifies if the Security is set to the parent of the Catalog Item.
 
         .EXAMPLE
             $Proxy = New-RsWebServiceProxyHelper -BoundParameters $PSBoundParameters
@@ -44,7 +44,10 @@ function New-RscatalogItemRoleObject
         [String]$Path,
 
         [Parameter(Mandatory=$True)]
-        [String]$TypeName
+        [String]$TypeName,
+
+        [Parameter(Mandatory=$True)]
+        [Boolean]$ParentSecurity
     )
     $catalogItemRoles = @()
 
@@ -55,6 +58,7 @@ function New-RscatalogItemRoleObject
         $catalogItemRole | Add-Member -MemberType NoteProperty -Name Path -Value $Path
         $catalogItemRole | Add-Member -MemberType NoteProperty -Name TypeName -Value $TypeName
         $catalogItemRole | Add-Member -MemberType NoteProperty -Name Roles -Value $_.Roles
+        $catalogItemRole | Add-Member -MemberType NoteProperty -Name ParentSecurity -Value $ParentSecurity
 
         $catalogItemRoles += $catalogItemRole
     }


### PR DESCRIPTION
Fixes # .

Changes proposed in this pull request:
 - I have added a property to the Get-RsCatalogItemRole function that shows if inheritance/Parent Security is enabled for each item. 
 - 
 - 

How to test this code:
 - Run the Get-RsCatalogItemRole tests.
 - 
 - 

Has been tested on (remove any that don't apply):
 - Powershell 3 and above
 - Windows 7 and above
 - SQL Server 2012 and above
