### PR TITLE
Adding support for SQL Server vNext

### DIFF
--- a/ReportingServicesTools/Libraries/library.ps1
+++ b/ReportingServicesTools/Libraries/library.ps1
@@ -109,7 +109,12 @@ namespace Microsoft.ReportingServicesTools
         /// <summary>
         /// SQL Server 2017
         /// </summary>
-        SQLServer2017 = 14
+        SQLServer2017 = 14,
+
+        /// <summary>
+        /// SQL Server vNext
+        /// </summary>
+        SQLServervNext = 15
     }
 }
 "@


### PR DESCRIPTION
Changes proposed in this pull request:
 - Extending the ReportServerVersion enum to include SQL Server vNext

Has been tested on (remove any that don't apply):
 - Powershell 5
 - Windows 10
 - Power BI Report Server
