### PR TITLE
Inherit recurse parameter

### DIFF
--- a/ReportingServicesTools/Functions/CatalogItems/Rest/Out-RsRestFolderContent.ps1
+++ b/ReportingServicesTools/Functions/CatalogItems/Rest/Out-RsRestFolderContent.ps1
@@ -174,7 +174,7 @@ function Out-RsRestFolderContent
                     New-Item -Path $subFolderPath -ItemType Directory | Out-Null
 
                     # download contents of the subfolder
-                    Out-RsRestFolderContent -RsFolder $catalogItem.Path -Destination $subFolderPath -ReportPortalUri $ReportPortalUri -RestApiVersion $RestApiVersion -Credential $Credential -WebSession $WebSession
+                    Out-RsRestFolderContent -RsFolder $catalogItem.Path -Destination $subFolderPath -ReportPortalUri $ReportPortalUri -RestApiVersion $RestApiVersion -Credential $Credential -WebSession $WebSession -Recurse
                 }
             }
             else


### PR DESCRIPTION
Recurse parameter should be inherited in order to get real recursive behaviour. Otherwise it only works for one subfolder layer.