### PR TITLE
Subscription fix

### DIFF
--- a/ReportingServicesTools/Functions/CatalogItems/Copy-RsSubscription.ps1
+++ b/ReportingServicesTools/Functions/CatalogItems/Copy-RsSubscription.ps1
@@ -127,7 +127,7 @@ function Copy-RsSubscription
                 if ($PSCmdlet.ShouldProcess($RsItem, "Creating new subscription"))
                 {
                     Write-Verbose "Creating Subscription..."
-                    if ($subscription.IsDataDriven)
+                    if ($sub.IsDataDriven)
                     {
                         $subscriptionId = $Proxy.CreateDataDrivenSubscription($RsItem, $sub.DeliverySettings, $sub.DataRetrievalPlan, $sub.Description, $sub.EventType, $sub.MatchData, $sub.Values)
                     }

--- a/ReportingServicesTools/Functions/CatalogItems/Copy-RsSubscription.ps1
+++ b/ReportingServicesTools/Functions/CatalogItems/Copy-RsSubscription.ps1
@@ -88,9 +88,7 @@ function Copy-RsSubscription
     Begin
     {
         $Proxy = New-RsWebServiceProxyHelper -BoundParameters $PSBoundParameters
-    }
-    Process
-    {
+
         #region Input Validation
         $itemNullOrEmpty = [System.String]::IsNullOrEmpty($RsItem)
         $folderNullOrEmpty = [System.String]::IsNullOrEmpty($RsFolder)
@@ -103,7 +101,9 @@ function Copy-RsSubscription
             throw 'Both folder and report path were specified! Please specify either -RsFolder or -RsItem.'
         }
         #endregion Input Validation
-
+    }
+    Process
+    {
         try
         {
             foreach ($sub in $Subscription)


### PR DESCRIPTION
Fixes #136 and #137.

Changes proposed in this pull request:
 - Variable used to check for DataDriven subscription was the collection and not the current item.
 - The input validation was moved to the Begin block

How to test this code:
Please take a look at issues #136 and #137

Has been tested on (remove any that don't apply):
 - Powershell 5
 - Windows 10
 - SQL Server 2016/2017
