### PR TITLE
Improve Error message on Grant-RsCatalogItemRole

### DIFF
--- a/ReportingServicesTools/Functions/Security/Grant-RsCatalogItemRole.ps1
+++ b/ReportingServicesTools/Functions/Security/Grant-RsCatalogItemRole.ps1
@@ -174,7 +174,7 @@ function Grant-RsCatalogItemRole
         }
         catch
         {
-            throw (New-Object System.Exception("Error occurred while granting $($role.Name) to $($policy.GroupUserName) on $Path! $($_.Exception.Message)", $_.Exception))
+            throw (New-Object System.Exception("Error occurred while granting $($role.Name) to $($policy.GroupUserName) on $Path! Please verify if you have typed the user full name. You can get the current permissions by running the Get-RsCatalogItemRole command. $($_.Exception.Message)", $_.Exception))
         }
         #endregion Assign Permissions
     }


### PR DESCRIPTION
Fixes #139.

Changes proposed in this pull request:
 - More verbose message when it fails

How to test this code:
 - Grant "NETWORK SERVICE" permissions using 
`Grant-RsCatalogItemRole -Proxy $proxy -Path "/London" -RoleName 'Publisher' -Identity 'NETWORK SERVICE'`
And then add again another different role
`Grant-RsCatalogItemRole -Proxy $proxy -Path "/London" -RoleName 'Browser' -Identity 'NETWORK SERVICE'`

![image](https://user-images.githubusercontent.com/19521315/36166232-bd3699b6-10e9-11e8-8431-8147002b5247.png)


Has been tested on (remove any that don't apply):
 - Powershell 5
 - Windows 10
 - SQL Server 2017
