### PR TITLE
Removed extraneous Parameter which was breaking

### DIFF
--- a/ReportingServicesTools/Functions/Admin/Set-RsDatabase.ps1
+++ b/ReportingServicesTools/Functions/Admin/Set-RsDatabase.ps1
@@ -102,7 +102,6 @@ function Set-RsDatabase
         [System.Management.Automation.PSCredential]
         $DatabaseCredential,
 
-        [Parameter]
         [Microsoft.ReportingServicesTools.SqlServerAuthenticationType]
         $AdminDatabaseCredentialType,
 


### PR DESCRIPTION
Fixes # .

Changes proposed in this pull request:
 - Error caused by extraneous `[Parameter]`; see [comment](https://github.com/Microsoft/ReportingServicesTools/pull/146#issuecomment-367858303) by @jtarquino 

How to test this code:
 - install and run

