### PR TITLE
Add parameter to Install.ps1 to specify version

### DIFF
--- a/Install.ps1
+++ b/Install.ps1
@@ -1,6 +1,7 @@
 [CmdletBinding()]
 param (
-    [string]$Path
+    [string]$Path,
+    [string]$Version = 'master'
 )
 
 $localpath = $(Join-Path -Path (Split-Path -Path $profile) -ChildPath '\Modules\ReportingServicesTools')
@@ -39,7 +40,7 @@ if ((Get-Command -Module ReportingServicesTools).count -ne 0)
     Remove-Module ReportingServicesTools -ErrorAction Stop
 }
 
-$url = 'https://github.com/Microsoft/ReportingServicesTools/archive/master.zip'
+$url = "https://github.com/Microsoft/ReportingServicesTools/archive/$Version.zip"
 
 $temp = ([System.IO.Path]::GetTempPath()).TrimEnd("\")
 $zipfile = "$temp\ReportingServicesTools.zip"
@@ -91,11 +92,11 @@ $shell = New-Object -COM Shell.Application
 $zipPackage = $shell.NameSpace($zipfile)
 $destinationFolder = $shell.NameSpace($temp)
 $destinationFolder.CopyHere($zipPackage.Items())
-Move-Item -Path "$temp\ReportingServicesTools-master\*" $path
+Move-Item -Path "$temp\ReportingServicesTools-$Version\*" $path
 Write-Output "ReportingServicesTools has been successfully downloaded to $path!"
 
 Write-Output "Cleaning up..."
-Remove-Item -Path "$temp\ReportingServicesTools-master"
+Remove-Item -Path "$temp\ReportingServicesTools-$Version"
 Remove-Item -Path $zipfile
 
 Write-Output "Importing ReportingServicesTools Module..."

--- a/Install.ps1
+++ b/Install.ps1
@@ -71,6 +71,7 @@ else
 }
 
 Write-Output "Downloading archive from ReportingServiceTools GitHub..."
+[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
 try
 {
     Invoke-WebRequest $url -OutFile $zipfile


### PR DESCRIPTION
Changes proposed in this pull request:
 - Allow the install script to be able to pick anther tag or branch than `master`, but fall back to the existing behaviour.
 - Ensure the webrequest to GH is using TLS 1.2 since older crypto has been turned off a few months ago https://blog.github.com/2018-02-23-weak-cryptographic-standards-removed/

How to test this code:
 - `.\Install.ps1 -Version 0.0.4.6`

Has been tested on (remove any that don't apply):
 - Powershell 3 and above
 - Windows 7 and above
