### PR TITLE
Fixes&enhancements to Write-Rs(Rest)FolderContent commands

### DIFF
--- a/ReportingServicesTools/Functions/CatalogItems/Rest/Write-RsRestFolderContent.ps1
+++ b/ReportingServicesTools/Functions/CatalogItems/Rest/Write-RsRestFolderContent.ps1
@@ -148,7 +148,6 @@ function Write-RsRestFolderContent
                 }
 
                 $uri = [String]::Format($folderUri, $folderUriPath)
-                Write-Output $uri
 
                 try
                 {

--- a/ReportingServicesTools/Functions/CatalogItems/Rest/Write-RsRestFolderContent.ps1
+++ b/ReportingServicesTools/Functions/CatalogItems/Rest/Write-RsRestFolderContent.ps1
@@ -151,7 +151,14 @@ function Write-RsRestFolderContent
                     $parentFolder = $RsFolder + $relativePath
                 }
 
-                Write-RsRestCatalogItem -WebSession $WebSession -RestApiVersion $RestApiVersion -Path $item.FullName -RsFolder $parentFolder -Overwrite:$Overwrite -Credential $Credential
+                try
+                {
+                    Write-RsRestCatalogItem -WebSession $WebSession -RestApiVersion $RestApiVersion -Path $item.FullName -RsFolder $parentFolder -Overwrite:$Overwrite -Credential $Credential
+                }
+                catch
+                {
+                    throw (New-Object System.Exception("Failed to create catalog item from '$($item.FullName)' in '$parentFolder': $($_.Exception)", $_.Exception))
+                }
             }
         }
     }

--- a/ReportingServicesTools/Functions/CatalogItems/Rest/Write-RsRestFolderContent.ps1
+++ b/ReportingServicesTools/Functions/CatalogItems/Rest/Write-RsRestFolderContent.ps1
@@ -99,6 +99,7 @@ function Write-RsRestFolderContent
         $WebSession = New-RsRestSessionHelper -BoundParameters $PSBoundParameters
         $ReportPortalUri = Get-RsPortalUriHelper -WebSession $WebSession
         $catalogItemsUri = $ReportPortalUri + "api/$RestApiVersion/CatalogItems"
+        $folderUri = $ReportPortalUri + "api/$RestApiVersion/Folders(Path='{0}')"
     }
     Process
     {
@@ -124,16 +125,67 @@ function Write-RsRestFolderContent
                 $relativePath = Clear-Substring -string $item.FullName -substring $sourceFolder.FullName.TrimEnd("\") -position front
                 $relativePath = Clear-Substring -string $relativePath -substring ("\" + $item.Name) -position back
                 $relativePath = $relativePath.replace("\", "/")
+
+                $folderUriPath = $null
+                $folderExists = $null
+                $folderInfo = $null
                 if ($RsFolder -eq "/" -and $relativePath -ne "")
                 {
                     $parentFolder = $relativePath
+                    $folderUriPath = "$RsFolder/$($item.name)"
                 }
                 else
                 {
                     $parentFolder = $RsFolder + $relativePath
+                    if ($RsFolder -eq "/")
+                    {
+                        $folderUriPath = $RsFolder + $($item.name)
+                    }
+                    else
+                    {
+                        $folderUriPath = "$RsFolder/$($item.name)"
+                    }
                 }
 
-                New-RsRestFolder -WebSession $WebSession -RestApiVersion $RestApiVersion -FolderName $item.Name -RsFolder $parentFolder | Out-Null
+                $uri = [String]::Format($folderUri, $folderUriPath)
+                Write-Output $uri
+
+                try
+                {
+                    # Try to get folder info
+                    if ($Credential -ne $null)
+                    {
+                        $response = Invoke-WebRequest -Uri $uri -Method Get -WebSession $WebSession -Credential $Credential -Verbose:$false
+                    }
+                    else
+                    {
+                        $response = Invoke-WebRequest -Uri $uri -Method Get -WebSession $WebSession -UseDefaultCredentials -Verbose:$false
+                    }
+
+                    # parsing response to get folder name
+                    $folderInfo = ConvertFrom-Json $response.Content
+                    if ($folderInfo.Name -eq $item.Name)
+                    {
+                        $folderExists = $true
+                    }
+                }
+                catch
+                {
+                    # Folder not found (404)
+                    if ($_.Exception.Response -ne $null -and $_.Exception.Response.StatusCode -eq "NotFound")
+                    {
+                        $folderExists = $false
+                    }
+                }
+
+                if ($folderExists)
+                {
+                    Write-Verbose "Folder $($item.Name) already exits. Skipping."
+                }
+                else
+                {
+                    New-RsRestFolder -WebSession $WebSession -RestApiVersion $RestApiVersion -FolderName $item.Name -RsFolder $parentFolder | Out-Null
+                }
             }
 
             if ($item.Extension -ne "")

--- a/ReportingServicesTools/Functions/CatalogItems/Rest/Write-RsRestFolderContent.ps1
+++ b/ReportingServicesTools/Functions/CatalogItems/Rest/Write-RsRestFolderContent.ps1
@@ -171,7 +171,7 @@ function Write-RsRestFolderContent
                 catch
                 {
                     # Folder not found (404)
-                    if ($_.Exception.Response -ne $null -and $_.Exception.Response.StatusCode -eq "NotFound")
+                    if ($_.Exception.Response -ne $null -and $_.Exception.Response.StatusCode -eq 404)
                     {
                         $folderExists = $false
                     }
@@ -208,7 +208,7 @@ function Write-RsRestFolderContent
                 }
                 catch
                 {
-                    throw (New-Object System.Exception("Failed to create catalog item from '$($item.FullName)' in '$parentFolder': $($_.Exception)", $_.Exception))
+                    Write-Error "Failed to create catalog item from '$($item.FullName)' in '$parentFolder': If the catalog item already exists (error: (409) Conflict), you can specify the -Overwrite parameter. $($_.Exception)"
                 }
             }
         }

--- a/ReportingServicesTools/Functions/CatalogItems/Write-RsFolderContent.ps1
+++ b/ReportingServicesTools/Functions/CatalogItems/Write-RsFolderContent.ps1
@@ -105,18 +105,26 @@ function Write-RsFolderContent
                 {
                     $parentFolder = $RsFolder + $relativePath
                 }
-                
+
                 Write-Verbose "Creating folder $parentFolder/$($item.Name)"
                 try
                 {
-                    $Proxy.CreateFolder($item.Name, $parentFolder, $null) | Out-Null
+                    if ($Proxy.GetItemType("$parentFolder/$($item.Name)") -ne "Folder" )
+                    {
+                        Write-Verbose "Creating folder $parentFolder/$($item.Name)"
+                        $Proxy.CreateFolder($item.Name, $parentFolder, $null) | Out-Null
+                    }
+                    else
+                    {
+                        Write-Verbose "Folder already exists $parentFolder/$($item.Name)"
+                    }
                 }
                 catch
                 {
                     throw (New-Object System.Exception("Failed to create folder '$($item.Name)' in '$parentFolder': $($_.Exception.Message)", $_.Exception))
                 }
             }
-            
+
             if ($item.Extension -eq ".rdl" -or
                 $item.Extension -eq ".rsds" -or
                 $item.Extension -eq ".rsd" -or

--- a/ReportingServicesTools/Functions/CatalogItems/Write-RsFolderContent.ps1
+++ b/ReportingServicesTools/Functions/CatalogItems/Write-RsFolderContent.ps1
@@ -106,7 +106,6 @@ function Write-RsFolderContent
                     $parentFolder = $RsFolder + $relativePath
                 }
 
-                Write-Verbose "Creating folder $parentFolder/$($item.Name)"
                 try
                 {
                     if ($Proxy.GetItemType("$parentFolder/$($item.Name)") -ne "Folder" )

--- a/Tests/CatalogItems/Rest/Write-RsRestFolderContent.Tests.ps1
+++ b/Tests/CatalogItems/Rest/Write-RsRestFolderContent.Tests.ps1
@@ -113,5 +113,9 @@ Describe "Write-RsRestFolderContent" {
 
             { Write-RsRestFolderContent -ReportPortalUri $reportPortalUri -Path $localFolderPath -RsFolder $rsFolderPath -Overwrite -Verbose } | Should Not Throw
         }
+
+        It "Do not halt even when folder already exists" {
+            { Write-RsRestFolderContent -WebSession $webSession -Path $localFolderPath -RsFolder $rsFolderPath -Recurse -Verbose } | Should Not Throw
+        }
     }
 }

--- a/Tests/CatalogItems/Rest/Write-RsRestFolderContent.Tests.ps1
+++ b/Tests/CatalogItems/Rest/Write-RsRestFolderContent.Tests.ps1
@@ -103,15 +103,15 @@ Describe "Write-RsRestFolderContent" {
         }
 
         It "Throws exception if resource already exists" {
-            Write-RsRestFolderContent -ReportPortalUri $reportPortalUri -Path $localFolderPath -RsFolder $rsFolderPath
+            Write-RsRestFolderContent -WebSession $webSession -Path $localFolderPath -RsFolder $rsFolderPath
 
-            { Write-RsRestFolderContent -ReportPortalUri $reportPortalUri -Path $localFolderPath -RsFolder $rsFolderPath -Verbose } | Should Throw
+            { Write-RsRestFolderContent -WebSession $webSession -Path $localFolderPath -RsFolder $rsFolderPath -Verbose } | Should Throw
         }
 
         It "Overwrites exisiting resource, if -Overwrite option is specified" {
-            Write-RsRestFolderContent -ReportPortalUri $reportPortalUri -Path $localFolderPath -RsFolder $rsFolderPath
+            Write-RsRestFolderContent -WebSession $webSession -Path $localFolderPath -RsFolder $rsFolderPath
 
-            { Write-RsRestFolderContent -ReportPortalUri $reportPortalUri -Path $localFolderPath -RsFolder $rsFolderPath -Overwrite -Verbose } | Should Not Throw
+            { Write-RsRestFolderContent -WebSession $webSession -Path $localFolderPath -RsFolder $rsFolderPath -Overwrite -Verbose } | Should Not Throw
         }
 
         It "Do not halt even when folder already exists" {

--- a/Tests/CatalogItems/Write-RsFolderContent.Tests.ps1
+++ b/Tests/CatalogItems/Write-RsFolderContent.Tests.ps1
@@ -80,14 +80,14 @@ Describe "Write-RsFolderContent" {
         $folderPath = '/' + $folderName
         $localReportPath =   (Get-Item -Path ".\" -Verbose).FullName  + '\Tests\CatalogItems\testResources'
         Write-RsFolderContent -Path $localReportPath -RsFolder $folderPath -Recurse
-       It "Should upload a local subFolder with Recurse Parameter" {
+        It "Should upload a local subFolder with Recurse Parameter" {
             $uploadedFolders = (Get-RsFolderContent -RsFolder $folderPath -Recurse ) | Where-Object TypeName -eq 'Folder' | Sort-Object -Property Name -Descending
             $uploadedFolders.Count | Should Be 2
             $uploadedFolders[0].Name | Should Be 'testResources2'
             $uploadedFolders[1].Name | Should Be 'datasources'
         }
 
-       It "Should upload a report that is in a folder and a second report that is in a subfolder" {
+        It "Should upload a report that is in a folder and a second report that is in a subfolder" {
             $uploadedReports = (Get-RsFolderContent -RsFolder $folderPath -Recurse ) | Where-Object TypeName -eq 'Report'
             $uploadedReports.Count | Should Be 4
         }
@@ -101,6 +101,12 @@ Describe "Write-RsFolderContent" {
             $uploadedDataSet = (Get-RsFolderContent -RsFolder $folderPath -Recurse ) | Where-Object TypeName -eq 'DataSet'
             $uploadedDataSet.Name | Should Be 'UnDataset'
         }
+
+        #Re-write folder with recurse.
+        It "Should not fail because folder already exists" {
+            { Write-RsFolderContent -Path $localReportPath -RsFolder $folderPath -Recurse -Overwrite } | Should Not Throw
+        }
+
         # Removing folders used for testing
         Remove-RsCatalogItem -RsFolder $folderPath -Confirm:$false
     }


### PR DESCRIPTION
Fixes:
- #114 
- #124 
- #157 
- #158 

Changes proposed in this pull request:
 - Handle when folder do not exist (Both commands)
 - Better error message and handle next item on error. (Rest command)

How to test this code:
- Please take a look on the issue that this PR solves.

Has been tested on (remove any that don't apply):
 - Powershell 5
 - Windows 10 
 - SQL Server 2017
