### PR TITLE
Get-RsCatalogItemRole with -Recurse 

### DIFF
--- a/ReportingServicesTools/Functions/Security/Get-RsCatalogItemRole.ps1
+++ b/ReportingServicesTools/Functions/Security/Get-RsCatalogItemRole.ps1
@@ -101,9 +101,9 @@ function Get-RsCatalogItemRole
 
         $parentType = $Proxy.GetItemType($Path)
 
-        $catalogItemRoles = New-RsCatalogItemRoleObject -Policy $parentPolicy -Path $Path -TypeName $parentType -ParentSecurity $false
+        $catalogItemRoles += New-RsCatalogItemRoleObject -Policy $parentPolicy -Path $Path -TypeName $parentType -ParentSecurity $false
 
-            
+
         if($Recurse -and $parentType -eq "Folder") {
 
             $GetRsFolderContentParam = @{


### PR DESCRIPTION
Fixes #153 .

Changes proposed in this pull request:
 - The first assignment needs to be a `+=` instead of just `=` otherwise we lose the collection and inside `-Recurse` the `+=` will fail.

How to test this code:
 - Please take a look on issue #153

Has been tested on (remove any that don't apply):
 - Powershell 5.1
 - Windows 10
 - SQL Server 2017
