### PR TITLE
Fixed mismatched parameter name in help text

### DIFF
--- a/ReportingServicesTools/Functions/Utilities/Connect-RsReportServer.ps1
+++ b/ReportingServicesTools/Functions/Utilities/Connect-RsReportServer.ps1
@@ -18,7 +18,7 @@ function Connect-RsReportServer
             The name of the SQL Instance to connect via WMI to.
             Only used for WMI access.
         
-        .PARAMETER Version
+        .PARAMETER ReportServerVersion
             The version of the SQL Server whose reporting services you connect to via WMI to.
             Only used for WMI access.
         


### PR DESCRIPTION
"Version" parameter in the comment-based help was mismatched with "ReportServerVersion" in the actual function definition. I believe this was causing blank documentation to be generated for get-help.

Changes proposed in this pull request:
 - Corrects mismatched parameter name in comment-based help.

How to test this code:
 - Build help files for this function and verify that the help text appears for `Get-Help Connect-RsReportServer -Parameter ReportServerVersion`