### PR TITLE
fix #76 Allow setting Hidden attribute on Folders and Hidden and Name on Catalog Items

### DIFF
--- a/ReportingServicesTools/Functions/CatalogItems/New-RsFolder.ps1
+++ b/ReportingServicesTools/Functions/CatalogItems/New-RsFolder.ps1
@@ -19,6 +19,9 @@ function New-RsFolder
         .PARAMETER Description
             Specify the description to be added to the new folder
 
+        .PARAMETER Hidden
+            Mark the item as hidden on the destination server.
+
         .PARAMETER ReportServerUri
             Specify the Report Server URL to your SQL Server Reporting Services Instance.
             Use the "Connect-RsReportServer" function to set/update a default value.
@@ -68,6 +71,9 @@ function New-RsFolder
         [string]
         $Description,
 
+        [switch]
+        $Hidden,
+
         [string]
         $ReportServerUri,
 
@@ -89,6 +95,14 @@ function New-RsFolder
         $descriptionProperty.Name = 'Description'
         $descriptionProperty.Value = $Description
         $additionalProperties.Add($descriptionProperty)
+    }
+
+    if ($Hidden)
+    {
+        $hiddenProperty = New-Object $propertyDataType
+        $hiddenProperty.Name = 'Hidden'
+        $hiddenProperty.Value = $Hidden
+        $additionalProperties.Add($hiddenProperty)
     }
 
     try

--- a/ReportingServicesTools/Functions/CatalogItems/Write-RsCatalogItem.ps1
+++ b/ReportingServicesTools/Functions/CatalogItems/Write-RsCatalogItem.ps1
@@ -24,6 +24,9 @@ function Write-RsCatalogItem
        .PARAMETER Overwrite
             Overwrite the old entry, if an existing catalog item with same name exists at the specified destination.
 
+        .PARAMETER Hidden
+            Mark the item as hidden on the destination server.
+
         .PARAMETER ReportServerUri
             Specify the Report Server URL to your SQL Server Reporting Services Instance.
             Use the "Connect-RsReportServer" function to set/update a default value.
@@ -61,6 +64,9 @@ function Write-RsCatalogItem
         [Alias('Override')]
         [switch]
         $Overwrite,
+
+        [switch]
+        $Hidden,
 
         [string]
         $ReportServerUri,
@@ -231,6 +237,14 @@ function Write-RsCatalogItem
 
                     $additionalProperties.Add($property)
 
+                    if ($Hidden)
+                    {
+                        $hiddenProperty = New-Object $propertyDataType
+                        $hiddenProperty.Name = 'Hidden'
+                        $hiddenProperty.Value = $Hidden
+                        $additionalProperties.Add($hiddenProperty)
+                    }
+                
                     $bytes = [System.IO.File]::ReadAllBytes($EntirePath)
                     $warnings = $null
                     try

--- a/ReportingServicesTools/Functions/CatalogItems/Write-RsCatalogItem.ps1
+++ b/ReportingServicesTools/Functions/CatalogItems/Write-RsCatalogItem.ps1
@@ -18,10 +18,13 @@ function Write-RsCatalogItem
         .PARAMETER RsFolder
             Folder on reportserver to upload the item to.
 
+        .PARAMETER Name
+            Specify the Name to be used for the report.
+
         .PARAMETER Description
             Specify the description to be added to the report.
 
-       .PARAMETER Overwrite
+        .PARAMETER Overwrite
             Overwrite the old entry, if an existing catalog item with same name exists at the specified destination.
 
         .PARAMETER Hidden
@@ -57,6 +60,9 @@ function Write-RsCatalogItem
         [Parameter(Mandatory = $True)]
         [string]
         $RsFolder,
+
+        [string]
+        $Name,
 
         [string]
         $Description,
@@ -98,7 +104,14 @@ function Write-RsCatalogItem
             $EntirePath = Convert-Path $item
             $item = Get-Item $EntirePath
             $itemType = Get-ItemType $item.Extension
-            $itemName = $item.BaseName
+            if ([string]::IsNullOrEmpty($Name))
+            {
+                $itemName = $item.BaseName
+            }
+            else
+            {
+                $itemName = $Name
+            }
 
             if (
                 (

--- a/Tests/CatalogItems/New-RsFolder.Tests.ps1
+++ b/Tests/CatalogItems/New-RsFolder.Tests.ps1
@@ -2,9 +2,22 @@
 # Licensed under the MIT License (MIT)
 
 Describe "New-RsFolder" {
-    Context "Create Folder with minimun parameters"{
+    Context "Create Folder with minimum parameters"{
         $folderName = 'SutFolderMinParameters' + [guid]::NewGuid()
         New-RsFolder -Path / -FolderName $folderName
+        $folderList = Get-RsFolderContent -RsFolder /
+        $folderCount = ($folderList | Where-Object name -eq $folderName).Count
+        $folderPath = '/' + $folderName
+        It "Should be a new folder" {
+            $folderCount | Should Be 1
+        }
+        # Removing folders used for testing
+        Remove-RsCatalogItem -ReportServerUri 'http://localhost/reportserver' -RsFolder $folderPath -Confirm:$false
+    }
+
+    Context "Create Folder with hidden parameter"{
+        $folderName = 'SutFolderHidden' + [guid]::NewGuid()
+        New-RsFolder -Path / -FolderName $folderName -Hidden
         $folderList = Get-RsFolderContent -RsFolder /
         $folderCount = ($folderList | Where-Object name -eq $folderName).Count
         $folderPath = '/' + $folderName

--- a/Tests/CatalogItems/Write-RsCatalogItem.Tests.ps1
+++ b/Tests/CatalogItems/Write-RsCatalogItem.Tests.ps1
@@ -65,6 +65,37 @@ Describe "Write-RsCatalogItem" {
         Remove-RsCatalogItem -RsFolder $folderPath -Confirm:$false
     }
 
+    Context "Write-RsCatalogItem with name parameter"{
+        $folderName = 'SutWriteRsCatalogItem_Name' + [guid]::NewGuid()
+        New-RsFolder -Path / -FolderName $folderName -Hidden
+        $folderPath = '/' + $folderName
+        $localPath =   (Get-Item -Path ".\").FullName  + '\Tests\CatalogItems\testResources'
+
+        It "Should upload a local report in Report Server" {
+            $localReportPath = $localPath + '\emptyReport.rdl'
+            Write-RsCatalogItem -Path $localReportPath -RsFolder $folderPath -Description 'newDescription' -Name 'Test Report'
+            $uploadedReport = (Get-RsFolderContent -RsFolder $folderPath ) | Where-Object TypeName -eq 'Report'
+            $uploadedReport.Name | Should Be 'Test Report'
+            $uploadedReport.Description | Should Be 'newDescription'
+        }
+
+        It "Should upload a local RsDataSource in Report Server" {
+            $localDataSourcePath = $localPath + '\SutWriteRsFolderContent_DataSource.rsds'
+            Write-RsCatalogItem -Path $localDataSourcePath -RsFolder $folderPath -Name 'Test DataSource'
+            $uploadedDataSource = (Get-RsFolderContent -RsFolder $folderPath ) | Where-Object TypeName -eq 'DataSource'
+            $uploadedDataSource.Name | Should Be 'Test DataSource'
+        }
+
+        It "Should upload a local DataSet in Report Server" {
+            $localDataSetPath = $localPath + '\UnDataset.rsd'
+            Write-RsCatalogItem -Path $localDataSetPath -RsFolder $folderPath -Name 'Test DataSet'
+            $uploadedDataSet = (Get-RsFolderContent -RsFolder $folderPath ) | Where-Object TypeName -eq 'DataSet'
+            $uploadedDataSet.Name | Should Be 'Test DataSet'
+        }
+        # Removing folders used for testing
+        Remove-RsCatalogItem -RsFolder $folderPath -Confirm:$false
+    }
+
     Context "Write-RsCatalogItem with Proxy parameter"{
         $folderName = 'SutWriteRsCatalogItem_ProxyParameter' + [guid]::NewGuid()
         New-RsFolder -Path / -FolderName $folderName

--- a/Tests/CatalogItems/Write-RsCatalogItem.Tests.ps1
+++ b/Tests/CatalogItems/Write-RsCatalogItem.Tests.ps1
@@ -34,6 +34,37 @@ Describe "Write-RsCatalogItem" {
         Remove-RsCatalogItem -RsFolder $folderPath -Confirm:$false
     }
 
+    Context "Write-RsCatalogItem with hidden parameters"{
+        $folderName = 'SutWriteRsCatalogItem_Hidden' + [guid]::NewGuid()
+        New-RsFolder -Path / -FolderName $folderName -Hidden
+        $folderPath = '/' + $folderName
+        $localPath =   (Get-Item -Path ".\").FullName  + '\Tests\CatalogItems\testResources'
+
+        It "Should upload a local report in Report Server" {
+            $localReportPath = $localPath + '\emptyReport.rdl'
+            Write-RsCatalogItem -Path $localReportPath -RsFolder $folderPath -Description 'newDescription' -Hidden
+            $uploadedReport = (Get-RsFolderContent -RsFolder $folderPath ) | Where-Object TypeName -eq 'Report'
+            $uploadedReport.Name | Should Be 'emptyReport'
+            $uploadedReport.Description | Should Be 'newDescription'
+        }
+
+        It "Should upload a local RsDataSource in Report Server" {
+            $localDataSourcePath = $localPath + '\SutWriteRsFolderContent_DataSource.rsds'
+            Write-RsCatalogItem -Path $localDataSourcePath -RsFolder $folderPath -Hidden
+            $uploadedDataSource = (Get-RsFolderContent -RsFolder $folderPath ) | Where-Object TypeName -eq 'DataSource'
+            $uploadedDataSource.Name | Should Be 'SutWriteRsFolderContent_DataSource'
+        }
+
+        It "Should upload a local DataSet in Report Server" {
+            $localDataSetPath = $localPath + '\UnDataset.rsd'
+            Write-RsCatalogItem -Path $localDataSetPath -RsFolder $folderPath -Hidden
+            $uploadedDataSet = (Get-RsFolderContent -RsFolder $folderPath ) | Where-Object TypeName -eq 'DataSet'
+            $uploadedDataSet.Name | Should Be 'UnDataset'
+        }
+        # Removing folders used for testing
+        Remove-RsCatalogItem -RsFolder $folderPath -Confirm:$false
+    }
+
     Context "Write-RsCatalogItem with Proxy parameter"{
         $folderName = 'SutWriteRsCatalogItem_ProxyParameter' + [guid]::NewGuid()
         New-RsFolder -Path / -FolderName $folderName


### PR DESCRIPTION
Fixes #76.

Changes proposed in this pull request:
 - Add Hidden parameter to the New-RsFolder and Write-RsCatalogitem methods to allow creation of hidden folders and catalog items
 - Add Name parameter to the Write-RsCatalogitem method to allow the name to be different to the name of the file being uploaded

How to test this code:
 - Added unit tests to New-RsFolder.Tests.ps1 and Write-RsCatalogItem.Tests.ps1

Has been tested on (remove any that don't apply):
 - Powershell 5
 - Windows 10
 - SQL Server 2017
