### PR TITLE
Additional Image Support in Write-RsCatalogItem

### DIFF
--- a/ReportingServicesTools/Functions/CatalogItems/Write-RsCatalogItem.ps1
+++ b/ReportingServicesTools/Functions/CatalogItems/Write-RsCatalogItem.ps1
@@ -122,11 +122,11 @@ function Write-RsCatalogItem
                 ) -or
                 (
                     $itemType -eq "Resource" -and
-                    $item.Extension -notin ('.png', '.jpg', '.jpeg')
+                    $item.Extension -notin ('.png', '.jpg', '.jpeg','.gif','.bmp')
                 )
             )
             {
-                throw "Invalid item specified! You can only upload Report, DataSource, DataSet and jpg/png files using this command!"
+                throw "Invalid item specified! You can only upload Report, DataSource, DataSet and jpg/png/gif/bmp files using this command!"
             }
 
             if ($RsFolder -eq "/")
@@ -231,6 +231,7 @@ function Write-RsCatalogItem
                         #If it is a resource we need to save the extension so the file can be recognized
                         $itemName = $item.Name
                         $property.Name = 'MimeType'
+                        <#
                         if ($item.Extension -eq ".png")
                         {
                             $property.Value = 'image/png'
@@ -238,6 +239,15 @@ function Write-RsCatalogItem
                         else
                         {
                             $property.Value = 'image/jpeg'
+                        }
+                        #>
+                        switch ($item.Extension)
+                        {
+                            '.png' {$property.Value = 'image/png'}
+                            {$_ -in '.jpg','.jpeg'} {$property.Value = 'image/jpeg'}
+                            '.gif' {$property.Value = 'image/gif'}
+                            '.bmp' {$property.Value = 'image/bmp'}
+                            Default {$property.Value = 'image/jpeg'}
                         }
                         $errorMessageItemType = 'resource'
                     }


### PR DESCRIPTION
Fixes # 214

Changes proposed in this pull request:
 - Adds support for .gif and .bmp image files and sets the MimeType
 - 
 - 

How to test this code:
 - Write-RsCatalogItem -Path E:\temp\bmp.bmp -RsFolder '/' -ReportServerUri http://localhost/reportserver_ssrs -Overwrite
 - Write-RsCatalogItem -Path E:\temp\gif.gif -RsFolder '/' -ReportServerUri http://localhost/reportserver_ssrs -Overwrite
 - 

Has been tested on (remove any that don't apply):
 - Powershell 5.1 and above
 - Windows Server 2016 and above
 - SQL Server Reporting Services 2017 and above

