### PR TITLE
Get-RsCatalogItemRole: fix bug that would always return false on inherited security

### DIFF
--- a/ReportingServicesTools/Functions/Security/Get-RsCatalogItemRole.ps1
+++ b/ReportingServicesTools/Functions/Security/Get-RsCatalogItemRole.ps1
@@ -6,10 +6,10 @@ function Get-RsCatalogItemRole
     <#
         .SYNOPSIS
             This script retrieves access to SQL Server Reporting Services Instance from users/groups.
-        
+
         .DESCRIPTION
             This script retrieves all access on the SQL Server Reporting Services Instance located at the specified Report Server URI from the specified user/group.
-        
+
         .PARAMETER Identity
             Specify the user or group name to retrieve access for.
 
@@ -18,26 +18,26 @@ function Get-RsCatalogItemRole
 
        .PARAMETER Recurse
             Recursively list subfolders with content.
-        
+
         .PARAMETER ReportServerUri
             Specify the Report Server URL to your SQL Server Reporting Services Instance.
             Use the "Connect-RsReportServer" function to set/update a default value.
-        
+
         .PARAMETER Credential
             Specify the credentials to use when connecting to the Report Server.
             Use the "Connect-RsReportServer" function to set/update a default value.
-        
+
         .PARAMETER Proxy
             Report server proxy to use.
             Use "New-RsWebServiceProxy" to generate a proxy object for reuse.
             Useful when repeatedly having to connect to multiple different Report Server.
-        
+
         .EXAMPLE
             Get-RsCatalogItemRole -Identity 'jmcgee'
             Description
             -----------
             This command will establish a connection to the Report Server located at http://localhost/reportserver using current user's credentials and then retrieves all access for user 'jmcgee'.
-        
+
         .EXAMPLE
             Get-RsCatalogItemRole -ReportServerUri 'http://localhost/reportserver_sql2012' -Identity 'jeremymcgee'
             Description
@@ -49,7 +49,7 @@ function Get-RsCatalogItemRole
             Description
             -----------
             This command will establish a connection to the Report Server located at http://localhost/reportserver_2012 using current user's credentials and then retrieves all access on catalog items found at '/Path/Human Resources/'.
-        
+
         .EXAMPLE
             Get-RsCatalogItemRole -Credential 'CaptainAwesome' -Identity 'jmcgee' -Recurse
             Description
@@ -62,29 +62,29 @@ function Get-RsCatalogItemRole
     (
         [string]
         $Identity,
-        
+
         [string]
         $Path = "/",
 
         [switch]
         $Recurse,
-        
+
         [string]
         $ReportServerUri,
-        
+
         [System.Management.Automation.PSCredential]
         $Credential,
-        
+
         $Proxy
     )
-    
+
     Begin
     {
 
         $Proxy = New-RsWebServiceProxyHelper -BoundParameters $PSBoundParameters
 
     }
-        
+
     Process
     {
 
@@ -101,7 +101,7 @@ function Get-RsCatalogItemRole
 
         $parentType = $Proxy.GetItemType($Path)
 
-        $catalogItemRoles += New-RsCatalogItemRoleObject -Policy $parentPolicy -Path $Path -TypeName $parentType -ParentSecurity $false
+        $catalogItemRoles += New-RsCatalogItemRoleObject -Policy $parentPolicy -Path $Path -TypeName $parentType -ParentSecurity $inheritParent
 
 
         if($Recurse -and $parentType -eq "Folder") {
@@ -136,7 +136,7 @@ function Get-RsCatalogItemRole
                     $catalogItemRoles +=  New-RsCatalogItemRoleObject -Policy $childPolicy -Path $item.Path -TypeName $item.TypeName -ParentSecurity $inheritParent
                 }
 
-                
+
             }
         }
 


### PR DESCRIPTION
Small bugfix to fix the fact that Get-RsCatalogItemRole always returns false when not used with -Recurse on the ParentSecurity property, even if permissions are inherited.

