### PR TITLE
Added code to handle restarting RS service with alternate credential

### DIFF
--- a/ReportingServicesTools/Functions/Admin/Restore-RsEncryptionKey.ps1
+++ b/ReportingServicesTools/Functions/Admin/Restore-RsEncryptionKey.ps1
@@ -6,38 +6,38 @@ function Restore-RSEncryptionKey
     <#
         .SYNOPSIS
             This script restores the SQL Server Reporting Services encryption key.
-        
+
         .DESCRIPTION
             This script restores encryption key for SQL Server Reporting Services. This key is needed in order to read all the encrypted content stored in the Reporting Services Catalog database.
-        
+
         .PARAMETER Password
             Specify the password that was used when the encryption key was backed up.
-        
+
         .PARAMETER KeyPath
             Specify the path to where the encryption key is stored.
-        
+
         .PARAMETER ReportServerInstance
             Specify the name of the SQL Server Reporting Services Instance.
             Use the "Connect-RsReportServer" function to set/update a default value.
-        
+
         .PARAMETER ReportServerVersion
             Specify the version of the SQL Server Reporting Services Instance.
             Use the "Connect-RsReportServer" function to set/update a default value.
-        
+
         .PARAMETER ComputerName
             The Report Server to target.
             Use the "Connect-RsReportServer" function to set/update a default value.
-        
+
         .PARAMETER Credential
             Specify the credentials to use when connecting to the Report Server.
             Use the "Connect-RsReportServer" function to set/update a default value.
-        
+
         .EXAMPLE
             Restore-RSEncryptionKey -Password 'Enter Your Password' -KeyPath 'C:\ReportingServices\Default.snk'
             Description
             -----------
             This command will restore the encryption key to the default instance from SQL Server 2016 Reporting Services
-        
+
         .EXAMPLE
             Restore-RSEncryptionKey -ReportServerInstance 'SQL2012' -ReportServerVersion '11' -Password 'Enter Your Password' -KeyPath 'C:\ReportingServices\Default.snk'
             Description
@@ -51,34 +51,34 @@ function Restore-RSEncryptionKey
         [Parameter(Mandatory = $True)]
         [string]
         $Password,
-        
+
         [Parameter(Mandatory = $True)]
         [string]
         $KeyPath,
-        
+
         [Alias('SqlServerInstance')]
         [string]
         $ReportServerInstance,
-        
+
         [Alias('SqlServerVersion')]
         [Microsoft.ReportingServicesTools.SqlServerVersion]
         $ReportServerVersion,
-        
+
         [string]
         $ComputerName,
-        
+
         [System.Management.Automation.PSCredential]
         $Credential
     )
-    
+
     if ($PSCmdlet.ShouldProcess((Get-ShouldProcessTargetWmi -BoundParameters $PSBoundParameters), "Restore encryptionkey from file $KeyPath"))
     {
         $rsWmiObject = New-RsConfigurationSettingObjectHelper -BoundParameters $PSBoundParameters
 
         $KeyPath = Resolve-Path $KeyPath
-        
+
         $reportServerService = 'ReportServer'
-        
+
         if ($rsWmiObject.InstanceName -ne "MSSQLSERVER")
         {
             if($rsWmiObject.InstanceName -eq "PBIRS")
@@ -90,13 +90,13 @@ function Restore-RSEncryptionKey
                 $reportServerService = $reportServerService + '$' + $rsWmiObject.InstanceName
             }
         }
-        
+
         Write-Verbose "Checking if key file path is valid..."
         if (-not (Test-Path $KeyPath))
         {
             throw "No key was found at the specified location: $path"
         }
-        
+
         try
         {
             $keyBytes = [System.IO.File]::ReadAllBytes($KeyPath)
@@ -105,10 +105,10 @@ function Restore-RSEncryptionKey
         {
             throw
         }
-        
+
         Write-Verbose "Restoring encryption key..."
         $restoreKeyResult = $rsWmiObject.RestoreEncryptionKey($keyBytes, $keyBytes.Length, $Password)
-        
+
         if ($restoreKeyResult.HRESULT -eq 0)
         {
             Write-Verbose "Success!"
@@ -117,17 +117,46 @@ function Restore-RSEncryptionKey
         {
             throw "Failed to restore the encryption key! Errors: $($restoreKeyResult.ExtendedErrors)"
         }
-        
+
         try
         {
-            $service = Get-Service -Name $reportServerService -ComputerName $rsWmiObject.PSComputerName -ErrorAction Stop
-            Write-Verbose "Stopping Reporting Services Service... $reportServerService"
-            $service.Stop()
-            $service.WaitForStatus([System.ServiceProcess.ServiceControllerStatus]::Stopped)
-            
-            Write-Verbose "Starting Reporting Services Service... $reportServerService"
-            $service.Start()
-            $service.WaitForStatus([System.ServiceProcess.ServiceControllerStatus]::Running)
+            # Restarting the Reporting Services Windows service requires a different method if a credential is passed because
+            # Get-Service does not have the ability to connect to a remote system with an alternate credential.
+            if ($PSBoundParameters.ContainsKey('Credential'))
+            {
+                $getServiceParams = @{
+                    Class        = 'Win32_Service'
+                    Filter       = "Name = '$reportServerService'"
+                    ComputerName = $rsWmiObject.PSComputerName
+                    Credential   = $Credential
+                }
+                $service = Get-WmiObject @getServiceParams
+
+                Write-Verbose "Stopping Reporting Services Service... $reportServerService"
+                $null = $service.StopService()
+                do {
+                    $service = Get-WmiObject @getServiceParams
+                    Start-Sleep -Seconds 1
+                } until ($service.State -eq 'Stopped')
+
+                Write-Verbose "Starting Reporting Services Service... $reportServerService"
+                $null = $service.StartService()
+                do {
+                    $service = Get-WmiObject @getServiceParams
+                    Start-Sleep -Seconds 1
+                } until ($service.State -eq 'Running')
+            }
+            else
+            {
+                $service = Get-Service -Name $reportServerService -ComputerName $rsWmiObject.PSComputerName -ErrorAction Stop
+                Write-Verbose "Stopping Reporting Services Service... $reportServerService"
+                $service.Stop()
+                $service.WaitForStatus([System.ServiceProcess.ServiceControllerStatus]::Stopped)
+
+                Write-Verbose "Starting Reporting Services Service... $reportServerService"
+                $service.Start()
+                $service.WaitForStatus([System.ServiceProcess.ServiceControllerStatus]::Running)
+            }
         }
         catch
         {


### PR DESCRIPTION
Fixes #228  .

Changes proposed in this pull request:
 - Added code to handle restarting RS service with alternate credential by using Get-WmiObject
 
How to test this code:
Assuming that `adminuser` user has access to the computer SSRS and the user running the command does not:

```powershell
Restore-RSEncryptionKey -KeyPath 'C:\MyFolder\MyKeyFile.snk' -Password 'MyPass' -ComputerName SSRS -Credential (Get-Credential adminuser)
```

Has been tested on (remove any that don't apply):
 - Powershell 5.1
 - Windows 10
 - SQL Server 2016