### PR TITLE
Use basic parsing

### DIFF
--- a/ReportingServicesTools/Functions/CatalogItems/Rest/Get-RsRestItemDataSource.ps1
+++ b/ReportingServicesTools/Functions/CatalogItems/Rest/Get-RsRestItemDataSource.ps1
@@ -84,11 +84,11 @@ function Get-RsRestItemDataSource
             $catalogItemsUri = [String]::Format($catalogItemsUri, $RsItem)
             if ($Credential -ne $null)
             {
-                $response = Invoke-WebRequest -Uri $catalogItemsUri -Method Get -WebSession $WebSession -Credential $Credential -Verbose:$false
+                $response = Invoke-WebRequest -Uri $catalogItemsUri -Method Get -WebSession $WebSession -Credential $Credential -Verbose:$false -UseBasicParsing
             }
             else
             {
-                $response = Invoke-WebRequest -Uri $catalogItemsUri -Method Get -WebSession $WebSession -UseDefaultCredentials -Verbose:$false
+                $response = Invoke-WebRequest -Uri $catalogItemsUri -Method Get -WebSession $WebSession -UseDefaultCredentials -Verbose:$false -UseBasicParsing
             }
 
             $item = ConvertFrom-Json $response.Content
@@ -99,11 +99,11 @@ function Get-RsRestItemDataSource
 
             if ($Credential -ne $null)
             {
-                $response = Invoke-WebRequest -Uri $dataSourcesUri -Method Get -WebSession $WebSession -Credential $Credential -Verbose:$false
+                $response = Invoke-WebRequest -Uri $dataSourcesUri -Method Get -WebSession $WebSession -Credential $Credential -Verbose:$false -UseBasicParsing
             }
             else
             {
-                $response = Invoke-WebRequest -Uri $dataSourcesUri -Method Get -WebSession $WebSession -UseDefaultCredentials -Verbose:$false
+                $response = Invoke-WebRequest -Uri $dataSourcesUri -Method Get -WebSession $WebSession -UseDefaultCredentials -Verbose:$false -UseBasicParsing
             }
 
             $itemWithDataSources = ConvertFrom-Json $response.Content

--- a/ReportingServicesTools/Functions/CatalogItems/Rest/New-RsRestFolder.ps1
+++ b/ReportingServicesTools/Functions/CatalogItems/Rest/New-RsRestFolder.ps1
@@ -91,11 +91,11 @@ function New-RsRestFolder
 
             if ($Credential -ne $null)
             {
-                $response = Invoke-WebRequest -Uri $foldersUri -Method Post -WebSession $WebSession -Body ([System.Text.Encoding]::UTF8.GetBytes($payloadJson)) -ContentType "application/json" -Credential $Credential -Verbose:$false
+                $response = Invoke-WebRequest -Uri $foldersUri -Method Post -WebSession $WebSession -Body ([System.Text.Encoding]::UTF8.GetBytes($payloadJson)) -ContentType "application/json" -Credential $Credential -Verbose:$false  -UseBasicParsing
             }
             else
             {
-                $response = Invoke-WebRequest -Uri $foldersUri -Method Post -WebSession $WebSession -Body ([System.Text.Encoding]::UTF8.GetBytes($payloadJson)) -ContentType "application/json" -UseDefaultCredentials -Verbose:$false
+                $response = Invoke-WebRequest -Uri $foldersUri -Method Post -WebSession $WebSession -Body ([System.Text.Encoding]::UTF8.GetBytes($payloadJson)) -ContentType "application/json" -UseDefaultCredentials -Verbose:$false  -UseBasicParsing
             }
 
             Write-Verbose "Folder $TargetFolderPath was created successfully!"

--- a/ReportingServicesTools/Functions/CatalogItems/Rest/Out-RsRestCatalogItem.ps1
+++ b/ReportingServicesTools/Functions/CatalogItems/Rest/Out-RsRestCatalogItem.ps1
@@ -114,11 +114,11 @@ function Out-RsRestCatalogItem
                 $url = [string]::Format($catalogItemsByPathApi, $item)
                 if ($Credential -ne $null)
                 {
-                    $response = Invoke-WebRequest -Uri $url -Method Get -Credential $Credential -Verbose:$false
+                    $response = Invoke-WebRequest -Uri $url -Method Get -Credential $Credential -Verbose:$false -UseBasicParsing
                 }
                 else
                 {
-                    $response = Invoke-WebRequest -Uri $url -Method Get -UseDefaultCredentials -Verbose:$false
+                    $response = Invoke-WebRequest -Uri $url -Method Get -UseDefaultCredentials -Verbose:$false -UseBasicParsing
                 }
             }
             catch

--- a/ReportingServicesTools/Functions/CatalogItems/Rest/Out-RsRestCatalogItemId.ps1
+++ b/ReportingServicesTools/Functions/CatalogItems/Rest/Out-RsRestCatalogItemId.ps1
@@ -128,11 +128,11 @@ function Out-RsRestCatalogItemId
             $url = [string]::Format($catalogItemContentApi, $itemId)
             if ($Credential -ne $null)
             {
-                $response = Invoke-WebRequest -Uri $url -Method Get -Credential $Credential -Verbose:$false
+                $response = Invoke-WebRequest -Uri $url -Method Get -Credential $Credential -Verbose:$false -UseBasicParsing
             }
             else
             {
-                $response = Invoke-WebRequest -Uri $url -Method Get -UseDefaultCredentials -Verbose:$false
+                $response = Invoke-WebRequest -Uri $url -Method Get -UseDefaultCredentials -Verbose:$false -UseBasicParsing
             }
         }
         catch

--- a/ReportingServicesTools/Functions/CatalogItems/Rest/Out-RsRestCatalogItemId.ps1
+++ b/ReportingServicesTools/Functions/CatalogItems/Rest/Out-RsRestCatalogItemId.ps1
@@ -82,7 +82,16 @@ function Out-RsRestCatalogItemId
         if ($RsItemInfo.Type -ne 'MobileReport')
         {
             $itemId = $RsItemInfo.Id
-            $fileName = $RsItemInfo.Name + (Get-FileExtension -TypeName $RsItemInfo.Type)
+            var $extension = "";
+            try {
+                $extension = (Get-FileExtension -TypeName $RsItemInfo.Type)
+            } 
+            catch
+            {
+                Write-Warning "Unsupported Type: $($RsItemInfo.Type) Unable to export: $($RsItemInfo.Name)"
+                break;
+            }
+            $fileName = $RsItemInfo.Name + $extension
         }
         else
         {

--- a/ReportingServicesTools/Functions/CatalogItems/Rest/Out-RsRestFolderContent.ps1
+++ b/ReportingServicesTools/Functions/CatalogItems/Rest/Out-RsRestFolderContent.ps1
@@ -108,11 +108,11 @@ function Out-RsRestFolderContent
                 $url = [string]::Format($catalogItemsByPathApiV1, $RsFolder)
                 if ($Credential -ne $null)
                 {
-                    $response = Invoke-WebRequest -Uri $url -Method Get -Credential $Credential -Verbose:$false
+                    $response = Invoke-WebRequest -Uri $url -Method Get -Credential $Credential -Verbose:$false -UseBasicParsing
                 }
                 else
                 {
-                    $response = Invoke-WebRequest -Uri $url -Method Get -UseDefaultCredentials -Verbose:$false
+                    $response = Invoke-WebRequest -Uri $url -Method Get -UseDefaultCredentials -Verbose:$false -UseBasicParsing
                 }
             }
             catch
@@ -128,11 +128,11 @@ function Out-RsRestFolderContent
                 $url = [string]::Format($folderCatalogItemsApiV1, $folder.Id)
                 if ($Credential -ne $null)
                 {
-                    $response = Invoke-WebRequest -Uri $url -Method Get -Credential $Credential -Verbose:$false
+                    $response = Invoke-WebRequest -Uri $url -Method Get -Credential $Credential -Verbose:$false -UseBasicParsing
                 }
                 else
                 {
-                    $response = Invoke-WebRequest -Uri $url -Method Get -UseDefaultCredentials -Verbose:$false
+                    $response = Invoke-WebRequest -Uri $url -Method Get -UseDefaultCredentials -Verbose:$false -UseBasicParsing
                 }
             }
             catch
@@ -148,11 +148,11 @@ function Out-RsRestFolderContent
                 $url = [string]::Format($folderCatalogItemsApiLatest, $RsFolder)
                 if ($Credential -ne $null)
                 {
-                    $response = Invoke-WebRequest -Uri $url -Method Get -Credential $Credential -Verbose:$false
+                    $response = Invoke-WebRequest -Uri $url -Method Get -Credential $Credential -Verbose:$false -UseBasicParsing
                 }
                 else
                 {
-                    $response = Invoke-WebRequest -Uri $url -Method Get -UseDefaultCredentials -Verbose:$false
+                    $response = Invoke-WebRequest -Uri $url -Method Get -UseDefaultCredentials -Verbose:$false -UseBasicParsing
                 }
             }
             catch

--- a/ReportingServicesTools/Functions/CatalogItems/Rest/Remove-RsRestCatalogItem.ps1
+++ b/ReportingServicesTools/Functions/CatalogItems/Rest/Remove-RsRestCatalogItem.ps1
@@ -76,11 +76,11 @@ function Remove-RsRestCatalogItem
     
                 if ($Credential -ne $null)
                 {
-                    Invoke-WebRequest -Uri $catalogItemsUri -Method Delete -WebSession $WebSession -Credential $Credential -Verbose:$false | Out-Null
+                    Invoke-WebRequest -Uri $catalogItemsUri -Method Delete -WebSession $WebSession -Credential $Credential -Verbose:$false -UseBasicParsing | Out-Null
                 }
                 else
                 {
-                    Invoke-WebRequest -Uri $catalogItemsUri -Method Delete -WebSession $WebSession -UseDefaultCredentials -Verbose:$false | Out-Null
+                    Invoke-WebRequest -Uri $catalogItemsUri -Method Delete -WebSession $WebSession -UseDefaultCredentials -Verbose:$false -UseBasicParsing | Out-Null
                 }
     
                 Write-Verbose "Catalog item $RsItem was deleted successfully!"

--- a/ReportingServicesTools/Functions/CatalogItems/Rest/Remove-RsRestFolder.ps1
+++ b/ReportingServicesTools/Functions/CatalogItems/Rest/Remove-RsRestFolder.ps1
@@ -76,11 +76,11 @@ function Remove-RsRestFolder
 
                 if ($Credential -ne $null)
                 {
-                    Invoke-WebRequest -Uri $foldersUri -Method Delete -WebSession $WebSession -Credential $Credential -Verbose:$false | Out-Null
+                    Invoke-WebRequest -Uri $foldersUri -Method Delete -WebSession $WebSession -Credential $Credential -Verbose:$false -UseBasicParsing -UseBasicParsing | Out-Null
                 }
                 else
                 {
-                    Invoke-WebRequest -Uri $foldersUri -Method Delete -WebSession $WebSession -UseDefaultCredentials -Verbose:$false | Out-Null
+                    Invoke-WebRequest -Uri $foldersUri -Method Delete -WebSession $WebSession -UseDefaultCredentials -Verbose:$false -UseBasicParsing -UseBasicParsing | Out-Null
                 }
 
                 Write-Verbose "Folder $RsFolder was deleted successfully!"

--- a/ReportingServicesTools/Functions/CatalogItems/Rest/Set-RsRestItemDataSource.ps1
+++ b/ReportingServicesTools/Functions/CatalogItems/Rest/Set-RsRestItemDataSource.ps1
@@ -235,11 +235,11 @@ function Set-RsRestItemDataSource
                 Write-Verbose "Updating data sources for $($RsItem)..."
                 if ($Credential -ne $null)
                 {
-                    Invoke-WebRequest -Uri $dataSourcesUri -Method $method -Body ([System.Text.Encoding]::UTF8.GetBytes($payloadJson)) -ContentType "application/json" -WebSession $WebSession -Credential $Credential -Verbose:$false | Out-Null
+                    Invoke-WebRequest -Uri $dataSourcesUri -Method $method -Body ([System.Text.Encoding]::UTF8.GetBytes($payloadJson)) -ContentType "application/json" -WebSession $WebSession -Credential $Credential -Verbose:$false -UseBasicParsing | Out-Null
                 }
                 else
                 {
-                    Invoke-WebRequest -Uri $dataSourcesUri -Method $method -Body ([System.Text.Encoding]::UTF8.GetBytes($payloadJson)) -ContentType "application/json" -WebSession $WebSession -UseDefaultCredentials -Verbose:$false | Out-Null
+                    Invoke-WebRequest -Uri $dataSourcesUri -Method $method -Body ([System.Text.Encoding]::UTF8.GetBytes($payloadJson)) -ContentType "application/json" -WebSession $WebSession -UseDefaultCredentials -Verbose:$false -UseBasicParsing | Out-Null
                 }
                 Write-Verbose "Data sources were updated successfully!"
             }

--- a/ReportingServicesTools/Functions/CatalogItems/Rest/Write-RsRestCatalogItem.ps1
+++ b/ReportingServicesTools/Functions/CatalogItems/Rest/Write-RsRestCatalogItem.ps1
@@ -245,11 +245,11 @@ function Write-RsRestCatalogItem
 
                 if ($Credential -ne $null)
                 {
-                    Invoke-WebRequest -Uri $catalogItemsUri -Method Post -WebSession $WebSession -Body ([System.Text.Encoding]::UTF8.GetBytes($payloadJson)) -ContentType "application/json" -Credential $Credential -Verbose:$false | Out-Null
+                    Invoke-WebRequest -Uri $catalogItemsUri -Method Post -WebSession $WebSession -Body ([System.Text.Encoding]::UTF8.GetBytes($payloadJson)) -ContentType "application/json" -Credential $Credential -Verbose:$false -UseBasicParsing | Out-Null
                 }
                 else
                 {
-                    Invoke-WebRequest -Uri $catalogItemsUri -Method Post -WebSession $WebSession -Body ([System.Text.Encoding]::UTF8.GetBytes($payloadJson)) -ContentType "application/json" -UseDefaultCredentials -Verbose:$false | Out-Null
+                    Invoke-WebRequest -Uri $catalogItemsUri -Method Post -WebSession $WebSession -Body ([System.Text.Encoding]::UTF8.GetBytes($payloadJson)) -ContentType "application/json" -UseDefaultCredentials -Verbose:$false -UseBasicParsing | Out-Null
                 }
 
                 Write-Verbose "$EntirePath was uploaded to $RsFolder successfully!"
@@ -264,11 +264,11 @@ function Write-RsRestCatalogItem
                         $uri = [String]::Format($catalogItemsByPathApi, $itemPath)
                         if ($Credential -ne $null)
                         {
-                            $response = Invoke-WebRequest -Uri $uri -Method Get -WebSession $WebSession -Credential $Credential -Verbose:$false
+                            $response = Invoke-WebRequest -Uri $uri -Method Get -WebSession $WebSession -Credential $Credential -Verbose:$false -UseBasicParsing
                         }
                         else
                         {
-                            $response = Invoke-WebRequest -Uri $uri -Method Get -WebSession $WebSession -UseDefaultCredentials -Verbose:$false
+                            $response = Invoke-WebRequest -Uri $uri -Method Get -WebSession $WebSession -UseDefaultCredentials -Verbose:$false -UseBasicParsing
                         }
 
                         # parsing response to get Id
@@ -279,11 +279,11 @@ function Write-RsRestCatalogItem
                         $uri = [String]::Format($catalogItemsUpdateUri, $itemId)
                         if ($Credential -ne $null)
                         {
-                            Invoke-WebRequest -Uri $uri -Method Put -WebSession $WebSession -Body ([System.Text.Encoding]::UTF8.GetBytes($payloadJson)) -ContentType "application/json" -Credential $Credential -Verbose:$false | Out-Null
+                            Invoke-WebRequest -Uri $uri -Method Put -WebSession $WebSession -Body ([System.Text.Encoding]::UTF8.GetBytes($payloadJson)) -ContentType "application/json" -Credential $Credential -Verbose:$false -UseBasicParsing | Out-Null
                         }
                         else
                         {
-                            Invoke-WebRequest -Uri $uri -Method Put -WebSession $WebSession -Body ([System.Text.Encoding]::UTF8.GetBytes($payloadJson)) -ContentType "application/json" -UseDefaultCredentials -Verbose:$false | Out-Null
+                            Invoke-WebRequest -Uri $uri -Method Put -WebSession $WebSession -Body ([System.Text.Encoding]::UTF8.GetBytes($payloadJson)) -ContentType "application/json" -UseDefaultCredentials -Verbose:$false -UseBasicParsing | Out-Null
                         }
                         Write-Verbose "$EntirePath was uploaded to $RsFolder successfully!"
                     }

--- a/ReportingServicesTools/Functions/CatalogItems/Rest/Write-RsRestFolderContent.ps1
+++ b/ReportingServicesTools/Functions/CatalogItems/Rest/Write-RsRestFolderContent.ps1
@@ -154,11 +154,11 @@ function Write-RsRestFolderContent
                     # Try to get folder info
                     if ($Credential -ne $null)
                     {
-                        $response = Invoke-WebRequest -Uri $uri -Method Get -WebSession $WebSession -Credential $Credential -Verbose:$false
+                        $response = Invoke-WebRequest -Uri $uri -Method Get -WebSession $WebSession -Credential $Credential -Verbose:$false -UseBasicParsing
                     }
                     else
                     {
-                        $response = Invoke-WebRequest -Uri $uri -Method Get -WebSession $WebSession -UseDefaultCredentials -Verbose:$false
+                        $response = Invoke-WebRequest -Uri $uri -Method Get -WebSession $WebSession -UseDefaultCredentials -Verbose:$false -UseBasicParsing
                     }
 
                     # parsing response to get folder name

--- a/ReportingServicesTools/Functions/Utilities/New-RsRestSession.ps1
+++ b/ReportingServicesTools/Functions/Utilities/New-RsRestSession.ps1
@@ -71,11 +71,11 @@ function New-RsRestSession
         Write-Verbose "Making call to $meUri to create a session..."
         if ($Credential)
         {
-            $result = Invoke-WebRequest -Uri $meUri -Credential $Credential -SessionVariable mySession -Verbose:$false -ErrorAction Stop
+            $result = Invoke-WebRequest -Uri $meUri -Credential $Credential -SessionVariable mySession -Verbose:$false -ErrorAction Stop -UseBasicParsing
         }
         else
         {
-            $result = Invoke-WebRequest -Uri $meUri -UseDefaultCredentials -SessionVariable mySession -Verbose:$false -ErrorAction Stop
+            $result = Invoke-WebRequest -Uri $meUri -UseDefaultCredentials -SessionVariable mySession -Verbose:$false -ErrorAction Stop -UseBasicParsing
         }
 
         if ($result.StatusCode -ne 200)


### PR DESCRIPTION
Changes proposed in this pull request:
 - Added the -UseBasicParsing parameter to all the calls to Invoke-WebRequest. This means that the user running commands that call this cmdlet does not need to have IE configured. This is useful if you are calling ReportingServicesTools commands from a SQL Agent job as the SQL Agent account may not have IE configured
 - Added try/catch to Out-RsRestCatalogItemId function to prevent errors when calling methods like Out-RestFolderContent and the folder contains items like linked reports that do not return a known extension

How to test this code:
 - Run Out-RestFolderContent on a folder containing a linked rdl report, it should report a warning, but run to completion
 - Run a script using a login that does not have IE configured (such as running via a SQL Agent job)

Has been tested on (remove any that don't apply):
 - Powershell 3 and above
 - Windows Server 2012 R2 and above
 - SQL Server 2017 and above
