### PR TITLE
Fix key access for collections with spaces in the keys

### DIFF
--- a/ReportingServicesTools/Functions/CatalogItems/New-RsDataSource.ps1
+++ b/ReportingServicesTools/Functions/CatalogItems/New-RsDataSource.ps1
@@ -205,7 +205,7 @@ function New-RsDataSource
         throw (New-Object System.Exception("Exception occurred while converting credential retrieval to enum! $($_.Exception.Message)", $_.Exception))
     }
 
-    $additionalProperties = New-Object System.Collections.Generic.List[$propertyDataType]
+    $additionalProperties = New-Object System.Collections.Generic.List["$propertyDataType"]
     if ($Description)
     {
         $descriptionProperty = New-Object $propertyDataType

--- a/ReportingServicesTools/Functions/CatalogItems/New-RsFolder.ps1
+++ b/ReportingServicesTools/Functions/CatalogItems/New-RsFolder.ps1
@@ -88,7 +88,7 @@ function New-RsFolder
 
     $namespace = $proxy.GetType().Namespace
     $propertyDataType = "$namespace.Property"
-    $additionalProperties = New-Object System.Collections.Generic.List[$propertyDataType]
+    $additionalProperties = New-Object System.Collections.Generic.List["$propertyDataType"]
     if ($Description)
     {
         $descriptionProperty = New-Object $propertyDataType

--- a/ReportingServicesTools/Functions/CatalogItems/Write-RsCatalogItem.ps1
+++ b/ReportingServicesTools/Functions/CatalogItems/Write-RsCatalogItem.ps1
@@ -223,7 +223,7 @@ function Write-RsCatalogItem
                 #region Upload other stuff
                 else
                 {
-                    $additionalProperties = New-Object System.Collections.Generic.List[$propertyDataType]
+                    $additionalProperties = New-Object System.Collections.Generic.List["$propertyDataType"]
                     $property = New-Object $propertyDataType
 
                     if ($itemType -eq 'Resource')

--- a/ReportingServicesTools/Functions/Common/ConnectionObjectRequests.ps1
+++ b/ReportingServicesTools/Functions/Common/ConnectionObjectRequests.ps1
@@ -43,7 +43,7 @@
     {
         if ($goodKeys -contains $key)
         {
-            $NewRsWebServiceProxyParam[$key] = $BoundParameters[$key]
+            $NewRsWebServiceProxyParam["$key"] = $BoundParameters["$key"]
         }
     }
     
@@ -96,7 +96,7 @@ function New-RsRestSessionHelper
     {
         if ($goodKeys -contains $key)
         {
-            $NewRsRestSessionParams[$key] = $BoundParameters[$key]
+            $NewRsRestSessionParams["$key"] = $BoundParameters["$key"]
         }
     }
 
@@ -184,7 +184,7 @@ function New-RsConfigurationSettingObjectHelper
     {
         if ($goodKeys -contains $key)
         {
-            $NewRsConfigurationSettingObjectParam[$key] = $BoundParameters[$key]
+            $NewRsConfigurationSettingObjectParam["$key"] = $BoundParameters["$key"]
         }
     }
     


### PR DESCRIPTION
Fixes # .

Changes proposed in this pull request:
 - Use double quotes to encase strings for collection access with keys. More details at https://docs.microsoft.com/en-us/previous-versions/windows/it-pro/windows-powershell-1.0/ee692792(v=technet.10)

How to test this code:
 - Use a report server with a space in the namespace
 - Open a proxy connection
 - Invoke New-RsFolder with a new folder
 - Expected: Folder is added
 - Actual: Line:91 in New-RsFolder will break: $additionalProperties = New-Object System.Collections.Generic.List[$propertyDataType] as there will be a space in the key.

Has been tested on (remove any that don't apply):
 - Powershell 5 and above
 - Windows 10 and above
 - SQL Server 2008 R2 and above
