### PR TITLE
CustomAuthentication switch

### DIFF
--- a/ReportingServicesTools/Functions/Common/ConnectionObjectRequests.ps1
+++ b/ReportingServicesTools/Functions/Common/ConnectionObjectRequests.ps1
@@ -12,6 +12,7 @@
             - Credential
             - Proxy
             - APIVersion
+            - CustomAuthentication
             These parameters are passed on to the New-RsWebServiceProxy function, unless Proxy was specified.
             If the bound parameters contain the proxy parameter, the function will return that object.
             All other bound parameters are ignored.
@@ -36,7 +37,7 @@
         return $BoundParameters["Proxy"]
     }
     
-    $goodKeys = @("ReportServerUri", "Credential", "ApiVersion")
+    $goodKeys = @("ReportServerUri", "Credential", "ApiVersion", "CustomAuthentication")
     $NewRsWebServiceProxyParam = @{ }
     
     foreach ($key in $BoundParameters.Keys)

--- a/ReportingServicesTools/Functions/Utilities/Connect-RsReportServer.ps1
+++ b/ReportingServicesTools/Functions/Utilities/Connect-RsReportServer.ps1
@@ -36,7 +36,10 @@ function Connect-RsReportServer
             The version of the API to use, 2010 by default. Sepcifiy '2005' or '2006' if you need
             to query a Sql Server Reporting Service Instance running a version prior to
             SQL Server 2008 R2 to access those respective APIs.
-                    
+        
+        .PARAMETER CustomAuthentication
+            If the server implements a custom authentication schema such as 'Forms' instead of standard Basic/NTLM.
+
         .EXAMPLE
             Connect-RsReportServer -ComputerName "srv-foobar" -ReportServerInstance "Northwind" -ReportServerUri "http://srv-foobar/reportserver/"
     
@@ -79,9 +82,13 @@ function Connect-RsReportServer
         [switch]
         $RegisterProxy,
 
+        [Alias('ApiVersion')]
         [ValidateSet('2005','2006','2010')]
         [string]
-        $SoapEndpointApiVersion = '2010'
+        $SoapEndpointApiVersion = '2010',
+
+        [switch]
+        $CustomAuthentication
     )
     
     if ($PSBoundParameters.ContainsKey("ComputerName"))
@@ -106,7 +113,7 @@ function Connect-RsReportServer
         [Microsoft.ReportingServicesTools.ConnectionHost]::ReportServerUri = $ReportServerUri
         try
         {
-            $proxy = New-RsWebServiceProxy -ReportServerUri ([Microsoft.ReportingServicesTools.ConnectionHost]::ReportServerUri) -Credential ([Microsoft.ReportingServicesTools.ConnectionHost]::Credential) -ApiVersion $SoapEndpointApiVersion -ErrorAction Stop
+            $proxy = New-RsWebServiceProxyHelper -BoundParameters $PSBoundParameters
             [Microsoft.ReportingServicesTools.ConnectionHost]::Proxy = $proxy
         }
         catch
@@ -115,7 +122,7 @@ function Connect-RsReportServer
         }
     }
 
-    if ($PSBoundParameters.ContainsKey("ReportPortalUri"))
+    if ($PSBoundParameters.ContainsKey("ReportPortalUri")) 
     {
         [Microsoft.ReportingServicesTools.ConnectionHost]::ReportPortalUri = $ReportPortalUri
     }


### PR DESCRIPTION
Enabling `CustomAuthentication` switch to invoke `LogonUser` method upon establishing a connection via the SOAP API with the passed credentials.

Fixes #160.

Changes proposed in this pull request:
 - Adds `CustomAuthentication` switch to `Connect-RsReportServer` and all other cmdlets that take `Credentials` and `ReportPortalUri` individually.
- Prompts for `Credentials` (via `Get-Credentials`) if none is passed via the equivalent parameter.
 - Executes the `LogonUser` SOAP API method upon creating the Web Service Proxy with the passed credential and stores the cookie in the session for subsequent calls.

How to test this code:
 - `Connect-RsReportServer -ReportServerUri http://localhost/ReportServer -CustomAuthentication -Verbose`
- `Get-RsCatalogItems -RsFolder /`

Has been tested on (remove any that don't apply):
 - Powershell 3 and above
 - Windows 7 and above
 - SQL Server 2012 and above
