### PR TITLE
Fixed support for SQL credentials in function

### DIFF
--- a/ReportingServicesTools/Functions/Admin/Set-RsDatabaseCredentials.ps1
+++ b/ReportingServicesTools/Functions/Admin/Set-RsDatabaseCredentials.ps1
@@ -135,7 +135,14 @@ function Set-RsDatabaseCredentials
         Write-Verbose "Executing database rights script..."
         try
         {
-            Invoke-Sqlcmd -ServerInstance $DatabaseServerName -Query $SQLscript -QueryTimeout $QueryTimeout -ErrorAction Stop
+            if ($isWindowsAccount)
+            {
+                Invoke-Sqlcmd -ServerInstance $DatabaseServerName -Query $SQLscript -QueryTimeout $QueryTimeout -ErrorAction Stop
+            }
+            else 
+            {
+                Invoke-Sqlcmd -ServerInstance $DatabaseServerName -Query $SQLscript -QueryTimeout $QueryTimeout -ErrorAction Stop -Username $username -Password $password
+            }
         }
         catch
         {


### PR DESCRIPTION
Fixes # .

Changes proposed in this pull request:
 - implemented a check for windows credentials which presumably should have existed (similar to the counterpart function, Set-RsDatabase).  The Set-RsDatabaseCredentials function was incorrectly forcing a windows authentication even if SQL was specified as the DatabaseCredentialType.

How to test this code:
 - Make a call to the Set-RsDatabaseCredentials function, specifying SQL as the DatabaseCredentialType.  Be sure to provide a correct value for DatabaseCredential, ReportServerInstance, and if applicable, ReportServerVersion.

Has been tested on (remove any that don't apply):
 - Powershell 5
 - Windows Server 2019
 - SQL Server 2016
