### PR TITLE
Added support for report parts

### DIFF
--- a/ReportingServicesTools/Functions/CatalogItems/Out-RsFolderContent.ps1
+++ b/ReportingServicesTools/Functions/CatalogItems/Out-RsFolderContent.ps1
@@ -106,7 +106,8 @@ function Out-RsFolderContent
         if ($item.TypeName -eq "Resource" -or 
             $item.TypeName -eq "Report" -or 
             $item.TypeName -eq "DataSource" -or 
-            $item.TypeName -eq "DataSet")
+            $item.TypeName -eq "DataSet"   -or 
+            $item.TypeName -eq "Component")
         {
             # We're relying on the fact that the implementation of Get-RsFolderContent will show us the folder before their content, 
             # when using the -recurse option, so we can assume that any subfolder will be created before we download the items it contains

--- a/ReportingServicesTools/Functions/Common/Get-FileExtension.ps1
+++ b/ReportingServicesTools/Functions/Common/Get-FileExtension.ps1
@@ -14,6 +14,7 @@
         'ExcelWorkbook' { return '' }
         'Resource' { return '' }
         'Kpi' { return '.kpi' }
+        'Component' { return '' }
         default      { throw 'Unsupported item type! We only support items which are of type Report, DataSet, DataSource, Mobile Report or Power BI Report' }
     }
 }


### PR DESCRIPTION
Fixes #279.

Changes proposed in this pull request:
 - Add file extension matching report part
 - Add type name matching report part
 - 

How to test this code:
 - Connect Connect to SSRS using `Connect-RsReportServer`
 - Execute` Out-RsFolderContent` pointing to folder containing report parts
 - Check if report parts is downloaded

Has been tested on (remove any that don't apply):
 - Powershell 3 and above
 - Windows 7 and above
 - SQL Server 2016 and above
