### PR TITLE
Update Import-RsSubscriptionXml.ps1

### DIFF
--- a/ReportingServicesTools/Functions/CatalogItems/Import-RsSubscriptionXml.ps1
+++ b/ReportingServicesTools/Functions/CatalogItems/Import-RsSubscriptionXml.ps1
@@ -37,12 +37,25 @@ function Import-RsSubscriptionXml {
             and output a PowerShell object with the result.
 
         .EXAMPLE
-            Import-RsSubscriptionXml .\MySubscriptions.xml | Set-RsSubscription -Path /Example/Report
+            Import-RsSubscriptionXml .\MySubscriptions.xml | Copy-RsSubscription -RsItem /Example/Report
+
+            Description
+            -----------
+            This command will import all the subscriptions contained in .\MySubscriptions.xml, recreate any SRSS specific properties
+            and pipe the results to Copy-RsSubscription which will add them to the /Example/Report report.
+            NOTE: You will need to supply the correct path for the -ReportServerUri parameter to both the Import-RsSubscriptionXml 
+            & Copy-RsSubscription functions.  It has been omitted from this example for brevity.
+
+        .EXAMPLE
+            Import-RsSubscriptionXml .\MySubscriptions.xml | 
+            Out-GridView -PassThru |
+            Copy-RsSubscription -RsItem /Example/Report
 
             Description
             -----------
             This command will import the subscriptions contained in .\MySubscriptions.xml, recreate any SRSS specific properties
-            and pipe the results to Set-RsSubscription which will add them to the /Example/Report report.
+            and output a PowerShell object with the result.  The Out-GridView cmdlet allows you to examine and optionally filter the
+            subscriptions from the .XML file, before adding them to the report via the Copy-RsSubscription function.
     #>
 
     [cmdletbinding()]


### PR DESCRIPTION
Fixes 1.

Changes proposed in this pull request:
Corrected the example of the Import-RsSubscriptionXml function to show Copy-RsSubscription function as the target of the pipeline.  The Set-RsSubscription function no longer supports this functionality.

How to test this code:
 - First, export the subscriptions from a report using the Export-RsSubscriptionXml
 - Follow the instructions in the updated example to apply the subscriptions from the file using the Import-RsSubscriptionXml and Copy-RsSubscription functions.

Has been tested on (remove any that don't apply):
 - PowerShell 5.1
 - Windows 10 and above
 - Power BI Report Server
