### PR TITLE
Update Copy-RsSubscription.ps1

### DIFF
--- a/ReportingServicesTools/Functions/CatalogItems/Copy-RsSubscription.ps1
+++ b/ReportingServicesTools/Functions/CatalogItems/Copy-RsSubscription.ps1
@@ -147,7 +147,7 @@ function Copy-RsSubscription
         }
         catch
         {
-            Write-Error "Error occurred while creating subscription $($subscriptionId)! $($_.Exception.Message)"
+            Write-Error "Error occurred while creating subscription $($sub.SubscriptionId) because: $($_.Exception.Message)"
         }
     }
 }

--- a/ReportingServicesTools/Functions/CatalogItems/Copy-RsSubscription.ps1
+++ b/ReportingServicesTools/Functions/CatalogItems/Copy-RsSubscription.ps1
@@ -147,7 +147,7 @@ function Copy-RsSubscription
         }
         catch
         {
-            throw (New-Object System.Exception("Exception occurred while creating subscription! $($_.Exception.Message)", $_.Exception))
+            "Error occurred while creating subscription $($subscriptionId)! $($_.Exception.Message)"
         }
     }
 }

--- a/ReportingServicesTools/Functions/CatalogItems/Copy-RsSubscription.ps1
+++ b/ReportingServicesTools/Functions/CatalogItems/Copy-RsSubscription.ps1
@@ -147,7 +147,7 @@ function Copy-RsSubscription
         }
         catch
         {
-            "Error occurred while creating subscription $($subscriptionId)! $($_.Exception.Message)"
+            Write-Error "Error occurred while creating subscription $($subscriptionId)! $($_.Exception.Message)"
         }
     }
 }


### PR DESCRIPTION
Fixes 1

Changes proposed in this pull request:
Removed `throw` keyword from catch block so that `Process` loop could continue trying to copy additional subscriptions in pipeline.

How to test this code:
Import or Copy multiple subscriptions including at least one subscription which should fail to import.  After failure, function should trying to copy additional subscriptions in pipeline.

Has been tested on (remove any that don't apply):
 - Powershell 5.1
 - Windows 10
 - Power BI Report Server
