### PR TITLE
Added logic to prepend folders with / when needed

### DIFF
--- a/ReportingServicesTools/Functions/CatalogItems/Get-RsDeploymentConfig.ps1
+++ b/ReportingServicesTools/Functions/CatalogItems/Get-RsDeploymentConfig.ps1
@@ -13,6 +13,24 @@ function Get-RsDeploymentConfig {
             Specify which configuration to use from the SSRS project file, if you already know it's name.
 
         .EXAMPLE
+            Get-RsDeploymentConfig -RsProjectFile 'C:\source\repos\SQL Server Performance Dashboard\SQL Server Performance Dashboard.rptproj' -ConfigurationToUse Release
+
+            FullPath               : Release
+            OverwriteDatasets      : False
+            OverwriteDataSources   : False
+            TargetReportFolder     : /SQL Server Performance Dashboard
+            TargetDatasetFolder    : /Datasets
+            TargetDatasourceFolder : /Data Sources
+            TargetReportPartFolder : Report Parts
+            TargetServerURL        : http://localhost/reportserver
+            RsProjectFolder        : C:\source\repos\SQL Server Performance Dashboard
+
+            Description
+            -----------
+            Retrieves all deployment settings for the 'Release' deployment configuration of the SQL Server Performance Dashboard.rptproj file.  
+            Then returns an object with all applicable settings from that deployment configuration.
+        
+        .EXAMPLE
             Get-RsDeploymentConfig -RsProjectFile 'C:\Users\Aaron\source\repos\Finance\Financial Reports\SSRS_FR\SSRS_FR.rptproj'
 
             Description
@@ -29,7 +47,7 @@ function Get-RsDeploymentConfig {
             After the selection is made, the applicable settings are stored in the $RSConfig variable.
         
         .EXAMPLE
-            $RSConfig = Get-RsDeploymentConfig -RsProjectFile 'C:\Users\Aaron\source\repos\Financial Reports\SSRS_FR\SSRS_FR.rptproj' -ConfigurationToUse Dev01 $RSConfig |
+            $RSConfig = Get-RsDeploymentConfig -RsProjectFile 'C:\Users\Aaron\source\repos\Financial Reports\SSRS_FR\SSRS_FR.rptproj' -ConfigurationToUse Dev01 |
             Add-Member -PassThru -MemberType NoteProperty -Name ReportPortal -Value 'http://localhost/PBIRSportal/'
             $RSConfig | Deploy-RsProject
 

--- a/ReportingServicesTools/Functions/CatalogItems/Publish-RsProject.ps1
+++ b/ReportingServicesTools/Functions/CatalogItems/Publish-RsProject.ps1
@@ -2,7 +2,7 @@ function Publish-RsProject
 {
     <#
         .SYNOPSIS
-            This script deploys a Reporting Services project to a Power BI Report Server.
+            This command deploys a Reporting Services project to a Power BI Report Server.
 
         .DESCRIPTION
             This function deploys a full SSRS project to a Power BI Report Server.
@@ -87,6 +87,9 @@ function Publish-RsProject
     Beginning deployment.
     Building folder structures...
     "
+    if(-not ($TargetReportFolder).StartsWith("/")){$TargetReportFolder = '/'+$TargetReportFolder}
+    if(-not ($TargetDatasetFolder).StartsWith("/")){$TargetDatasetFolder = '/'+$TargetDatasetFolder}
+    if(-not ($TargetDatasourceFolder).StartsWith("/")){$TargetDatasourceFolder = '/'+$TargetDatasourceFolder}
 
     $TargetReportFolder, $TargetDatasourceFolder, $TargetDatasetFolder | 
     sort -Unique | 

--- a/Tests/CatalogItems/Publish-RsProject.Test.ps1
+++ b/Tests/CatalogItems/Publish-RsProject.Test.ps1
@@ -1,7 +1,7 @@
 $reportPortalUri = if ($env:PesterPortalUrl -eq $null) { 'http://localhost/reports' } else { $env:PesterPortalUrl }
 
 Describe "Publish-RsProject" {
-    Context "Deploy an entire SSRS Project by getting the DeploymentConfig of a ReportServer project file using ConfigurationToUse parameter"{
+    Context "Deploy an entire SSRS Project by getting the Release DeploymentConfig of a ReportServer project file using ConfigurationToUse parameter"{
         # Create a folder
         $RSConfig = Get-RsDeploymentConfig -RsProjectFile "$($PSScriptRoot)\TestProjects\SQLServerPerformanceDashboardReportingSolution\SQL Server Performance Dashboard\SQL Server Performance Dashboard.rptproj" -ConfigurationToUse Release |
         Add-Member -PassThru -MemberType NoteProperty -Name ReportPortal -Value $reportPortalUri
@@ -19,13 +19,41 @@ Describe "Publish-RsProject" {
         $RSConfig | Publish-RsProject
         $CatalogList = Get-RsRestFolderContent -reportPortalUri $RSConfig.ReportPortal -RsFolder '/SQL Server Performance Dashboard' -Recurse
         $folderCount = ($CatalogList | measure).Count
-        It "Should find at least 1 folder" {
+        It "Should find 22 reports inside the folder" {
             $folderCount | Should Be 22
         }
         # Removing folders used for testing
         Remove-RsCatalogItem -RsFolder $RSConfig.TargetReportFolder -Confirm:$false
         Remove-RsCatalogItem -RsFolder $RSConfig.TargetDatasetFolder -Confirm:$false
         Remove-RsCatalogItem -RsFolder $RSConfig.TargetDatasourceFolder -Confirm:$false
+        
+    }
+
+    Context "Deploy an entire SSRS Project by getting the Debug DeploymentConfig of a ReportServer project file using ConfigurationToUse parameter"{
+        # Create a folder
+        $RSConfig = Get-RsDeploymentConfig -RsProjectFile "$($PSScriptRoot)\TestProjects\SQLServerPerformanceDashboardReportingSolution\SQL Server Performance Dashboard\SQL Server Performance Dashboard.rptproj" -ConfigurationToUse Debug |
+        Add-Member -PassThru -MemberType NoteProperty -Name ReportPortal -Value $reportPortalUri
+        
+        # Test if the config was retrieved
+        It "Should verify a config was retrieved" {
+            @($RSConfig).Count | Should Be 1
+        }
+        
+        # Test if the TargetServerURL in the config was found
+        It "Should verify TargetServerURL matches" {
+            $RSConfig.TargetServerURL | Should Be 'http://localhost/reportserver'
+        }
+
+        $RSConfig | Publish-RsProject
+        $CatalogList = Get-RsRestFolderContent -reportPortalUri $RSConfig.ReportPortal -RsFolder '/SQL Server Performance Dashboard' -Recurse
+        $folderCount = ($CatalogList | measure).Count
+        It "Should find 22 reports inside the folder" {
+            $folderCount | Should Be 22
+        }
+        # Removing folders used for testing
+        Remove-RsCatalogItem -RsFolder "/$($RSConfig.TargetReportFolder)" -Confirm:$false
+        Remove-RsCatalogItem -RsFolder "/$($RSConfig.TargetDatasetFolder)" -Confirm:$false
+        Remove-RsCatalogItem -RsFolder "/$($RSConfig.TargetDatasourceFolder)" -Confirm:$false
         
     }
 }    


### PR DESCRIPTION
Added logic to prepend folders with '/' when needed.

Only affects $TargetReportFolder, $TargetDatasourceFolder, $TargetDatasetFolder

Fixes issue when .rptproj file contains $TargetReportFolder, $TargetDatasourceFolder, and/or $TargetDatasetFolder which do not begin with '/'.

Changes proposed in this pull request:
 - Added logic to prepend folders with '/' when needed
 - Updated Test to include this scenario - 

How to test this code:
 - Use the updated Publish-RsProject.Test.ps1 file.

Has been tested on (remove any that don't apply):
 - PowerShell 5.1 and above
 - Windows 10 and above
 - Power BI Report Server and above
