### PR TITLE
Add -LiteralPath to Test-Path and Convert-Path

### DIFF
--- a/ReportingServicesTools/Functions/CatalogItems/Out-RsCatalogItem.ps1
+++ b/ReportingServicesTools/Functions/CatalogItems/Out-RsCatalogItem.ps1
@@ -7,45 +7,45 @@ function Out-RsCatalogItem
     <#
         .SYNOPSIS
             This downloads catalog items from a report server to disk.
-        
+
         .DESCRIPTION
             This downloads catalog items from a report server to disk.
             Currently supported types to download are reports, datasources, datasets and resources.
-        
+
         .PARAMETER RsItem
             Path to catalog item to download.
-        
+
         .PARAMETER Destination
             Folder to download catalog item to.
-        
+
         .PARAMETER ReportServerUri
             Specify the Report Server URL to your SQL Server Reporting Services Instance.
             Use the "Connect-RsReportServer" function to set/update a default value.
-        
+
         .PARAMETER Credential
             Specify the credentials to use when connecting to the Report Server.
             Use the "Connect-RsReportServer" function to set/update a default value.
-        
+
         .PARAMETER Proxy
             Report server proxy to use.
             Use "New-RsWebServiceProxy" to generate a proxy object for reuse.
             Useful when repeatedly having to connect to multiple different Report Server.
-        
+
         .EXAMPLE
             Out-RsCatalogItem -ReportServerUri 'http://localhost/reportserver_sql2012' -RsItem /Report -Destination C:\reports
-            
+
             Description
             -----------
             Download catalog item 'Report' to folder 'C:\reports'.
 
         .EXAMPLE
-            Get-RsFolderContent -ReportServerUri http://localhost/ReportServer -RsItem '/SQL Server Performance Dashboard' | 
-            WHERE Name -Like Wait* | 
+            Get-RsFolderContent -ReportServerUri http://localhost/ReportServer -RsItem '/SQL Server Performance Dashboard' |
+            WHERE Name -Like Wait* |
             Out-RsCatalogItem -ReportServerUri http://localhost/ReportServer -Destination c:\SQLReports
-   
+
     Description
     -----------
-    Downloads all catalog items from folder '/SQL Server Performance Dashboard' with a name that starts with 'Wait' to folder 'C:\SQLReports'. 			
+    Downloads all catalog items from folder '/SQL Server Performance Dashboard' with a name that starts with 'Wait' to folder 'C:\SQLReports'.
     #>
     [CmdletBinding()]
     param (
@@ -53,29 +53,29 @@ function Out-RsCatalogItem
         [Parameter(Mandatory = $True, ValueFromPipeline = $true)]
         [string[]]
         $RsItem,
-        
-        [ValidateScript({ Test-Path $_ -PathType Container})]
+
+        [ValidateScript({ Test-Path -LiteralPath $_ -PathType Container})]
         [Parameter(Mandatory = $True)]
         [string]
         $Destination,
-        
+
         [string]
         $ReportServerUri,
-        
+
         [Alias('ReportServerCredentials')]
         [System.Management.Automation.PSCredential]
         $Credential,
-        
+
         $Proxy
     )
-    
+
     Begin
     {
         $Proxy = New-RsWebServiceProxyHelper -BoundParameters $PSBoundParameters
-        
-        $DestinationFullPath = Convert-Path $Destination
+
+        $DestinationFullPath = Convert-Path -LiteralPath $Destination
     }
-    
+
     Process
     {
         #region Processing each path passed to it
@@ -90,7 +90,7 @@ function Out-RsCatalogItem
             {
                 throw (New-Object System.Exception("Failed to retrieve item type of '$item' from proxy: $($_.Exception.Message)", $_.Exception))
             }
-            
+
             switch ($itemType)
             {
                 "Unknown"
@@ -106,7 +106,7 @@ function Out-RsCatalogItem
                     $fileName = "$(($item.Split("/"))[-1])$(Get-FileExtension -TypeName $itemType)"
                 }
             }
-            
+
             Write-Verbose "Downloading $item..."
             try
             {
@@ -117,7 +117,7 @@ function Out-RsCatalogItem
                 throw (New-Object System.Exception("Failed to retrieve item definition of '$item' from proxy: $($_.Exception.Message)", $_.Exception))
             }
             #endregion Retrieving content from Report Server
-            
+
             #region Writing results to file
             Write-Verbose "Writing $itemType content to $DestinationFullPath\$fileName..."
             try
@@ -136,15 +136,15 @@ function Out-RsCatalogItem
             {
                 throw (New-Object System.IO.IOException("Failed to write content to '$DestinationFullPath\$fileName' : $($_.Exception.Message)", $_.Exception))
             }
-            
+
             Write-Verbose "$item was downloaded to $DestinationFullPath\$fileName successfully!"
             #endregion Writing results to file
         }
         #endregion Processing each path passed to it
     }
-    
+
     End
     {
-        
+
     }
 }

--- a/ReportingServicesTools/Functions/CatalogItems/Rest/Out-RsRestCatalogItem.ps1
+++ b/ReportingServicesTools/Functions/CatalogItems/Rest/Out-RsRestCatalogItem.ps1
@@ -33,14 +33,14 @@ function Out-RsRestCatalogItem
 
         .EXAMPLE
             Out-RsRestCatalogItem -RsItem '/Report' -Destination 'C:\reports'
-            
+
             Description
             -----------
             Downloads the catalog item 'Report' to folder 'C:\reports' using v2.0 REST Endpoint from the Report Server located at http://localhost/reports.
 
         .EXAMPLE
             Out-RsRestCatalogItem -RsItem '/Report' -Destination 'C:\reports' -RestApiVersion 'v1.0'
-            
+
             Description
             -----------
             Downloads the catalog item 'Report' to folder 'C:\reports' using v1.0 REST Endpoint from the Report Server located at http://localhost/reports.
@@ -54,7 +54,7 @@ function Out-RsRestCatalogItem
 
         .EXAMPLE
             Out-RsRestCatalogItem -ReportPortalUri 'http://myserver/reports' -RsItem '/Report' -Destination 'C:\reports'
-            
+
             Description
             -----------
             Downloads the catalog item found at '/Report' to folder 'C:\reports' using v2.0 REST Endpoint from the Report Server located at http://myserver/reports.
@@ -67,7 +67,7 @@ function Out-RsRestCatalogItem
         [string[]]
         $RsItem,
 
-        [ValidateScript({ Test-Path $_ -PathType Container})]
+        [ValidateScript({Test-Path -LiteralPath $_ -PathType Container})]
         [Parameter(Mandatory = $True)]
         [string]
         $Destination,

--- a/ReportingServicesTools/Functions/CatalogItems/Rest/Out-RsRestCatalogItemId.ps1
+++ b/ReportingServicesTools/Functions/CatalogItems/Rest/Out-RsRestCatalogItemId.ps1
@@ -37,7 +37,7 @@ function Out-RsRestCatalogItemId
         [Parameter(Mandatory = $True)]
         $RsItemInfo,
 
-        [ValidateScript({ Test-Path $_ -PathType Container})]
+        [ValidateScript({Test-Path -LiteralPath $_ -PathType Container})]
         [Parameter(Mandatory = $True)]
         [string]
         $Destination,
@@ -66,7 +66,7 @@ function Out-RsRestCatalogItemId
         $WebSession = New-RsRestSessionHelper -BoundParameters $PSBoundParameters
         $ReportPortalUri = Get-RsPortalUriHelper -WebSession $WebSession
         $catalogItemContentApi = $ReportPortalUri + "api/$RestApiVersion/CatalogItems({0})/Content/`$value"
-        $DestinationFullPath = Convert-Path $Destination
+        $DestinationFullPath = Convert-Path -LiteralPath $Destination
 
         # basic validation of RsItemInfo by checking properties that would be defined on a valid RsItemInfo object
         if ($RsItemInfo.Id -eq $null -or
@@ -145,4 +145,3 @@ function Out-RsRestCatalogItemId
         Write-Verbose "$($RsItemInfo.Path) was downloaded to $destinationFilePath successfully!"
     }
 }
-

--- a/ReportingServicesTools/Functions/CatalogItems/Rest/Out-RsRestFolderContent.ps1
+++ b/ReportingServicesTools/Functions/CatalogItems/Rest/Out-RsRestFolderContent.ps1
@@ -33,28 +33,28 @@ function Out-RsRestFolderContent
 
         .EXAMPLE
             Out-RsRestFolderContent -RsFolder /folder -Destination 'C:\reports'
-            
+
             Description
             -----------
             Downloads all items found under '/folder' folder to 'C:\reports' using v2.0 REST Endpoint from the Report Server located at http://localhost/reports.
 
         .EXAMPLE
             Out-RsRestFolderContent -RsFolder '/folder' -Destination 'C:\reports' -RestApiVersion 'v1.0'
-            
+
             Description
             -----------
             Downloads all items found under '/folder' folder to 'C:\reports' using v1.0 REST Endpoint from the Report Server located at http://localhost/reports.
 
         .EXAMPLE
             Out-RsRestFolderContent -WebSession $mySession -RsFolder '/folder' -Destination 'C:\reports'
-            
+
             Description
             -----------
             Downloads all items found under '/folder' folder to 'C:\reports' using v2.0 REST Endpoint from the Report Server located at specified WebSession object.
 
         .EXAMPLE
             Out-RsRestFolderContent -ReportPortalUri 'http://myserver/reports' -RsFolder '/folder' -Destination 'C:\reports'
-            
+
             Description
             -----------
             Downloads all items found under '/folder' folder to 'C:\reports' using v2.0 REST Endpoint from the Report Server located at http://myserver/reports.
@@ -66,7 +66,7 @@ function Out-RsRestFolderContent
         [string]
         $RsFolder,
 
-        [ValidateScript({ Test-Path $_ -PathType Container})]
+        [ValidateScript({Test-Path -LiteralPath $_ -PathType Container})]
         [Parameter(Mandatory = $True)]
         [string]
         $Destination,


### PR DESCRIPTION
Fixes #302

Changes proposed in this pull request:
 - Added -LiteralPath to Test-Path in parameter on Out-RsRestCatalogItem, Out-RsRestCatalogItemId, Out-RsRestFolderContent, Out-RsCatalogItem and Out-RsFolderContent
 - Added -LiteralPath to Convert-Path on RsRestCatalogItemId, Out-RsCatalogItem and Out-RsFolderContent


How to test this code:
 - Run it on regular folders without issue, as before
 - Run it on folders that have [] in their name

Has been tested on (remove any that don't apply):
 - Powershell 5 and Powershell 7
 - Windows 10 and Windows Server 2019
 - PowerBI Report Server September 2019
