### PR TITLE
SQLvariant Test-RsRestItemDataSource

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,8 +44,10 @@ The following is a list of commands which are available for you to use once you 
 |Get-RsItemDataSource|This command fetches embedded data sources associated to a report.|
 |Get-RsCatalogItemRole|This command retrieves access on catalog items for users or groups.|
 |Get-RsRestCacheRefreshPlan|This function fetches a CacheRefreshPlan from a Power BI report.|
+|Get-RsRestCacheRefreshPlanHistory|This function fetches the history of CacheRefreshPlan(s) from a Power BI report.|
 |Get-RsRestFolderContent|This function fetches data sources related to a catalog item from the Report Server.|
 |Get-RsRestItem|This function fetches a catalog item from the Report Server using the REST API.|
+|Get-RsRestItemAccess|This function retrieves access policies to SQL Server Reporting Services Instance or Power BI Report Server Instance from users/groups.|
 |Get-RsRestItemDataModelParameters|This function fetches the Data Model Parameters related to a Catalog Item report from the Report Server. This is currently only applicable to Power BI Reports and only from ReportServer October/2020 or higher.|
 |Get-RsRestItemDataSource|This command fetches embedded data sources associated to a Paginated report or a Power BI report using the REST Endpoint.|
 |Get-RsSubscription|This command retrieves information about subscriptions for a report.|
@@ -92,6 +94,7 @@ The following is a list of commands which are available for you to use once you 
 |Set-PbiRsUrlReservation|This command configures the Power BI Report Server URLs.|
 |Set-RsSubscription|This command updates existing subscriptions piped from Get-RsSubscription|
 |Start-RsRestCacheRefreshPlan|This function fetches the CacheRefreshPlan of a report from the Report Server, and refreshes them using the REST API.  Alternatively, when a report has multiple CacheRefreshPlans you can sopecify which CacheRefreshPlan to refresh by passing the Id of the CacheRefreshPlan to the -Id parameter.|
+|Test-RsRestItemDataSource|This function fetches the DataSources from a Paginated or Power BI report and tests them to see if the connection can be made.|
 |Write-RsCatalogItem|This command uploads a report, a dataset or a data source using the SOAP Endpoint..|
 |Write-RsFolderContent|This uploads all reports, datasets and data sources in a folder.|
 |Write-RsRestCatalogItem|This command uploads a report, a dataset or a mobile report using the REST Endpoint.|

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ The following is a list of commands which are available for you to use once you 
 |Get-RsRestCacheRefreshPlanHistory|This function fetches the history of CacheRefreshPlan(s) from a Power BI report.|
 |Get-RsRestFolderContent|This function fetches data sources related to a catalog item from the Report Server.|
 |Get-RsRestItem|This function fetches a catalog item from the Report Server using the REST API.|
-|Get-RsRestItemAccess|This function retrieves access policies to SQL Server Reporting Services Instance or Power BI Report Server Instance from users/groups.|
+|Get-RsRestItemAccessPolicy|This function retrieves access policies to SQL Server Reporting Services Instance or Power BI Report Server Instance from users/groups.|
 |Get-RsRestItemDataModelParameters|This function fetches the Data Model Parameters related to a Catalog Item report from the Report Server. This is currently only applicable to Power BI Reports and only from ReportServer October/2020 or higher.|
 |Get-RsRestItemDataSource|This command fetches embedded data sources associated to a Paginated report or a Power BI report using the REST Endpoint.|
 |Get-RsSubscription|This command retrieves information about subscriptions for a report.|

--- a/ReportingServicesTools/Functions/CatalogItems/Rest/Test-RsRestItemDataSource.ps1
+++ b/ReportingServicesTools/Functions/CatalogItems/Rest/Test-RsRestItemDataSource.ps1
@@ -2,16 +2,14 @@ function Test-RsRestItemDataSource
 {
     <#
         .SYNOPSIS
-            This function fetches the history of CacheRefreshPlan(s) from a Power BI report.
+            This function fetches the DataSources from a Paginated or Power BI report and tests them to see if the connection can be made.
 
         .DESCRIPTION
-            This function fetches the history of CacheRefreshPlan(s) from a Power BI report.
+            This function fetches the DataSources from a Paginated or Power BI report and tests them to see if the connection can be made.
+            It tests using the connection information currently stopred in the report.
 
         .PARAMETER RsReport
-            Specify the location of the Power BI report for which the CacheRefreshPlans should be fetched.
-
-        .PARAMETER Id
-            Specify the Id of the CacheRefreshPlan for a Power BI report which should be fetched.
+            Specify the location of the Power BI report for which the DataSources should be fetched.
 
         .PARAMETER ReportPortalUri
             Specify the Report Portal URL to your Power BI Report Server Instance.
@@ -29,25 +27,19 @@ function Test-RsRestItemDataSource
             Test-RsRestItemDataSource -RsReport "/MyReport"
             Description
             -----------
-            Fetches the history of all CacheRefreshPlans for the "MyReport" catalog item found in "/" folder from the Report Server located at http://localhost/reports.
+            Fetches all the DataSources for the "MyReport" catalog item found in "/" folder from the Report Server located at http://localhost/reports, and tests them to see if they can connect.
 
         .EXAMPLE
             Test-RsRestItemDataSource -RsReport "/MyReport" -WebSession $session
             Description
             -----------
-            Fetches the history of all CacheRefreshPlans for the "MyReport" catalog item found in "/" folder from the Report Server located at specificed WebSession object.
+            Fetches all the DataSources for the "MyReport" catalog item found in "/" folder from the Report Server located at specificed WebSession object, and tests them to see if they can connect.
         
         .EXAMPLE
             Test-RsRestItemDataSource -RsReport "/MyReport" -ReportPortalUri http://myserver/reports
             Description
             -----------
-            Fetches the history of all CacheRefreshPlans for the "MyReport" catalog item found in "/" folder from the Report Server located at http://myserver/reports.
-
-        .EXAMPLE
-            Test-RsRestItemDataSource -Id 'f8796f95-31c8-46fe-b184-4677cbbf5abf' -ReportPortalUri http://myserver/reports
-            Description
-            -----------
-            Fetches the history of all CacheRefreshPlans for the "Finance" report from the Report Server located at http://myserver/reports.
+            Fetches all the DataSources for the "MyReport" catalog item found in "/" folder from the Report Server located at http://myserver/reports, and tests them to see if they can connect.
     #>
 
     [CmdletBinding()]
@@ -60,11 +52,6 @@ function Test-RsRestItemDataSource
         [Parameter(Mandatory = $false, ValueFromPipelineByPropertyName = $true)]
         [string]
         $ReportPortalUri,
-
-        [Parameter(Mandatory = $false, ValueFromPipelineByPropertyName = $true)]
-        [Alias('CacheRefreshPlan')]
-        [string]
-        $Id = $null,
 
         [Parameter(Mandatory = $false, ValueFromPipelineByPropertyName = $true)]
         [Alias('ApiVersion')]

--- a/ReportingServicesTools/Functions/CatalogItems/Rest/Test-RsRestItemDataSource.ps1
+++ b/ReportingServicesTools/Functions/CatalogItems/Rest/Test-RsRestItemDataSource.ps1
@@ -1,0 +1,157 @@
+function Test-RsRestItemDataSource
+{
+    <#
+        .SYNOPSIS
+            This function fetches the history of CacheRefreshPlan(s) from a Power BI report.
+
+        .DESCRIPTION
+            This function fetches the history of CacheRefreshPlan(s) from a Power BI report.
+
+        .PARAMETER RsReport
+            Specify the location of the Power BI report for which the CacheRefreshPlans should be fetched.
+
+        .PARAMETER Id
+            Specify the Id of the CacheRefreshPlan for a Power BI report which should be fetched.
+
+        .PARAMETER ReportPortalUri
+            Specify the Report Portal URL to your Power BI Report Server Instance.
+
+        .PARAMETER RestApiVersion
+            Specify the version of REST Endpoint to use. Valid values are: "v2.0".
+
+        .PARAMETER Credential
+            Specify the credentials to use when connecting to the Report Server.
+
+        .PARAMETER WebSession
+            Specify the session to be used when making calls to REST Endpoint.
+
+        .EXAMPLE
+            Test-RsRestItemDataSource -RsReport "/MyReport"
+            Description
+            -----------
+            Fetches the history of all CacheRefreshPlans for the "MyReport" catalog item found in "/" folder from the Report Server located at http://localhost/reports.
+
+        .EXAMPLE
+            Test-RsRestItemDataSource -RsReport "/MyReport" -WebSession $session
+            Description
+            -----------
+            Fetches the history of all CacheRefreshPlans for the "MyReport" catalog item found in "/" folder from the Report Server located at specificed WebSession object.
+        
+        .EXAMPLE
+            Test-RsRestItemDataSource -RsReport "/MyReport" -ReportPortalUri http://myserver/reports
+            Description
+            -----------
+            Fetches the history of all CacheRefreshPlans for the "MyReport" catalog item found in "/" folder from the Report Server located at http://myserver/reports.
+
+        .EXAMPLE
+            Test-RsRestItemDataSource -Id 'f8796f95-31c8-46fe-b184-4677cbbf5abf' -ReportPortalUri http://myserver/reports
+            Description
+            -----------
+            Fetches the history of all CacheRefreshPlans for the "Finance" report from the Report Server located at http://myserver/reports.
+    #>
+
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory = $false, ValueFromPipelineByPropertyName = $true)]
+        [Alias('ItemPath','Path', 'RsItem')]
+        [string]
+        $RsReport,
+
+        [Parameter(Mandatory = $false, ValueFromPipelineByPropertyName = $true)]
+        [string]
+        $ReportPortalUri,
+
+        [Parameter(Mandatory = $false, ValueFromPipelineByPropertyName = $true)]
+        [Alias('CacheRefreshPlan')]
+        [string]
+        $Id = $null,
+
+        [Parameter(Mandatory = $false, ValueFromPipelineByPropertyName = $true)]
+        [Alias('ApiVersion')]
+        [ValidateSet("v2.0")]
+        [string]
+        $RestApiVersion = "v2.0",
+
+        [Parameter(Mandatory = $false, ValueFromPipelineByPropertyName = $true)]
+        [Alias('ReportServerCredentials')]
+        [System.Management.Automation.PSCredential]
+        $Credential,
+
+        [Parameter(Mandatory = $false, ValueFromPipelineByPropertyName = $true)]
+        [Microsoft.PowerShell.Commands.WebRequestSession]
+        $WebSession
+    )
+    Begin
+    {
+        $WebSession = New-RsRestSessionHelper -BoundParameters $PSBoundParameters
+        $ReportPortalUri = Get-RsPortalUriHelper -WebSession $WebSession
+    }
+    Process
+    {
+
+        if ($Credential -ne $null)
+        {
+            $Report = Get-RsRestItem -ReportPortalUri $ReportPortalUri -RsItem $RsReport -Credential $Credential -Verbose:$false
+            $ReportDataSources = Get-RsRestItemDataSource -ReportPortalUri $ReportPortalUri -RsItem $Report.Path -WebSession $WebSession -Credential $Credential -Verbose:$false
+        }
+        else
+        {
+            $Report = Get-RsRestItem -ReportPortalUri $ReportPortalUri -RsItem $RsReport -WebSession $WebSession -Verbose:$false
+            $ReportDataSources = Get-RsRestItemDataSource -ReportPortalUri $ReportPortalUri -RsItem $Report.Path -WebSession $WebSession -Verbose:$false
+        }
+
+        $DataSourceResponses = @()
+        if($Report.Type -eq 'Report'){
+            <# Paginated #>
+            foreach($ReportDataSource in $ReportDataSources){
+                $payload = @{
+                "DataSourceName" = "$($ReportDataSource.Name)"
+                }
+                $payloadJson = ConvertTo-Json $payload -Depth 15
+        
+                $DataSourceConnectionUri = $ReportPortalUri + "api/$RestApiVersion/Reports({0})/Model.CheckDataSourceConnection"
+                $DataSourceConnectionUri = [String]::Format($DataSourceConnectionUri, $Report.Id)
+                Write-Verbose "$DataSourceConnectionUri"
+                if ($Credential -ne $null)
+                {
+                    $PostResponse = Invoke-RestMethod -Uri $DataSourceConnectionUri -Method Post -Body ([System.Text.Encoding]::UTF8.GetBytes($payloadJson)) -ContentType "application/json" -Credential $Credential -Verbose:$false
+                }
+                else
+                {
+                    $PostResponse = Invoke-RestMethod -Uri $DataSourceConnectionUri -Method Post -Body ([System.Text.Encoding]::UTF8.GetBytes($payloadJson)) -ContentType "application/json" -WebSession $WebSession -UseDefaultCredentials -Verbose:$false
+                }
+                $PostResponse | Add-Member -MemberType NoteProperty -Name ReportName -Value $Report.Name
+                $PostResponse | Add-Member -MemberType NoteProperty -Name DataSourceName -Value $ReportDataSource.Name
+                $PostResponse | Add-Member -MemberType NoteProperty -Name DataSourceId -Value $ReportDataSource.Id
+                $DataSourceResponses += $PostResponse
+            }
+            return $DataSourceResponses
+        }
+        elseif($Report.Type -eq 'PowerBIReport'){
+            <# PBI #>
+            foreach($ReportDataSource in $ReportDataSources){
+                $payload = @{
+                "DataSourceName" = "$($ReportDataSource.id)"
+                }
+                $payloadJson = ConvertTo-Json $payload -Depth 15
+        
+                $DataSourceConnectionUri = $ReportPortalUri + "api/$RestApiVersion/PowerBIReports({0})/Model.CheckDataSourceConnection"
+                $DataSourceConnectionUri = [String]::Format($DataSourceConnectionUri, $Report.Id)
+                Write-Verbose "$DataSourceConnectionUri"
+                if ($Credential -ne $null)
+                {
+                    $PostResponse = Invoke-RestMethod -Uri $DataSourceConnectionUri -Method Post -Body ([System.Text.Encoding]::UTF8.GetBytes($payloadJson)) -ContentType "application/json" -Credential $Credential -Verbose:$false
+                }
+                else
+                {
+                    $PostResponse = Invoke-RestMethod -Uri $DataSourceConnectionUri -Method Post -Body ([System.Text.Encoding]::UTF8.GetBytes($payloadJson)) -ContentType "application/json" -WebSession $WebSession -UseDefaultCredentials -Verbose:$false
+                }
+                $PostResponse | Add-Member -MemberType NoteProperty -Name ReportName -Value $Report.Name
+                $PostResponse | Add-Member -MemberType NoteProperty -Name DataSourceName -Value $ReportDataSource.Name
+                $PostResponse | Add-Member -MemberType NoteProperty -Name DataSourceId -Value $ReportDataSource.Id
+                $DataSourceResponses += $PostResponse
+            }
+            return $DataSourceResponses
+        }
+    }
+}

--- a/ReportingServicesTools/ReportingServicesTools.psd1
+++ b/ReportingServicesTools/ReportingServicesTools.psd1
@@ -121,6 +121,7 @@
         'Set-RsUrlReservation',
         'Set-PbiRsUrlReservation',
         'Start-RsRestCacheRefreshPlan',
+        'Test-RsRestItemDataSource',
         'Write-RsCatalogItem',
         'Write-RsFolderContent',
         'Write-RsRestCatalogItem',

--- a/Tests/CatalogItems/Rest/Test-RsRestItemDataSource.Tests.ps1
+++ b/Tests/CatalogItems/Rest/Test-RsRestItemDataSource.Tests.ps1
@@ -4,7 +4,7 @@
 $reportPortalUri = if ($env:PesterPortalUrl -eq $null) { 'http://localhost/reports' } else { $env:PesterPortalUrl }
 $reportServerUri = if ($env:PesterServerUrl -eq $null) { 'http://localhost/reportserver' } else { $env:PesterServerUrl }
 
-Describe "Get-RsRestItemDataSource" {
+Describe "Test-RsRestItemDataSource" {
     $session = $null
     $rsFolderPath = ""
     $datasourcesReport = ""

--- a/Tests/CatalogItems/Rest/Test-RsRestItemDataSource.Tests.ps1
+++ b/Tests/CatalogItems/Rest/Test-RsRestItemDataSource.Tests.ps1
@@ -14,7 +14,7 @@ Describe "Test-RsRestItemDataSource" {
         $session = New-RsRestSession -ReportPortalUri $reportPortalUri
 
         # creating test folder
-        $folderName = 'SUT_GetRsRestItemDataSource_' + [guid]::NewGuid()
+        $folderName = 'SUT_TestRsRestItemDataSource_' + [guid]::NewGuid()
         New-RsRestFolder -WebSession $session -RsFolder / -FolderName $folderName
         $rsFolderPath = '/' + $folderName
 

--- a/Tests/CatalogItems/Rest/Test-RsRestItemDataSource.Tests.ps1
+++ b/Tests/CatalogItems/Rest/Test-RsRestItemDataSource.Tests.ps1
@@ -1,0 +1,105 @@
+# Copyright (c) 2021 Microsoft Corporation. All Rights Reserved.
+# Licensed under the MIT License (MIT)
+
+$reportPortalUri = if ($env:PesterPortalUrl -eq $null) { 'http://localhost/reports' } else { $env:PesterPortalUrl }
+$reportServerUri = if ($env:PesterServerUrl -eq $null) { 'http://localhost/reportserver' } else { $env:PesterServerUrl }
+
+Describe "Get-RsRestItemDataSource" {
+    $session = $null
+    $rsFolderPath = ""
+    $datasourcesReport = ""
+    $sqlPowerBIReport = ""
+
+    BeforeEach {
+        $session = New-RsRestSession -ReportPortalUri $reportPortalUri
+
+        # creating test folder
+        $folderName = 'SUT_GetRsRestItemDataSource_' + [guid]::NewGuid()
+        New-RsRestFolder -WebSession $session -RsFolder / -FolderName $folderName
+        $rsFolderPath = '/' + $folderName
+
+        # uploading test artifacts: datasourcesReport.rdl and SqlPowerBIReport.pbix
+        $localPath =   (Get-Item -Path ".\").FullName  + '\Tests\CatalogItems\testResources'
+        Write-RsRestCatalogItem -WebSession $session -Path "$localPath\datasources\datasourcesReport.rdl" -RsFolder $rsFolderPath
+        $datasourcesReport =  "$rsFolderPath/datasourcesReport"
+
+        Write-RsRestCatalogItem -WebSession $session -Path "$localPath\SqlPowerBIReport.pbix" -RsFolder $rsFolderPath
+        $sqlPowerBIReport = "$rsFolderPath/SqlPowerBIReport"
+    }
+
+    AfterEach {
+        # deleting test folder
+        Remove-RsRestFolder -WebSession $session -RsFolder $rsFolderPath -Confirm:$false
+    }
+
+    Context "ReportPortalUri parameter" {
+        It "fetches data sources for paginated reports" {
+            $datasources = Get-RsRestItemDataSource -ReportPortalUri $reportPortalUri -RsItem $datasourcesReport -Verbose
+            $datasources.Count | Should Be 2
+            $datasources[0].DataSourceType | Should Be "SQL"
+            $datasources[0].DataSourceSubType | Should BeNullOrEmpty 
+            $datasources[0].ConnectionString | Should Be "Data Source=localhost;Initial Catalog=master"
+            $datasources[1].DataSourceType | Should Be "SQL"
+            $datasources[1].DataSourceSubType | Should BeNullOrEmpty
+            $datasources[1].ConnectionString | Should Be "Data Source=localhost;Initial Catalog=model"
+            
+            $TestResponse = Test-RsRestItemDataSource -ReportPortalUri $reportPortalUri -RsItem $datasourcesReport -Verbose
+            $TestResponse[0].IsSuccessful | Should be "True"
+            $TestResponse[0].ErrorMessage | Should be $null
+            $TestResponse[1].IsSuccessful | Should be "True"
+            $TestResponse[1].ErrorMessage | Should be $null
+
+        }
+
+        It "tests data sources for power bi reports, and expects failure responses" {
+            $datasources = Get-RsRestItemDataSource -ReportPortalUri $reportPortalUri -RsItem $sqlPowerBIReport -Verbose
+            $datasources.GetType() | Should BeOfType System.Object
+            $datasources.DataSourceSubType | Should Be "DataModel"
+            $datasources.ConnectionString | Should Be "localhost;ReportServer"
+
+            $TestResponse = Test-RsRestItemDataSource -ReportPortalUri $reportPortalUri -RsItem $sqlPowerBIReport -Verbose
+            $TestResponse.IsSuccessful | Should be "False"
+            $TestResponse.ErrorMessage | Should be "A user name wasn't specified"
+        }
+
+        It "tests data sources for power bi reports, and expects success responses" {
+            $datasources = Get-RsRestItemDataSource -ReportPortalUri $reportPortalUri -RsItem $sqlPowerBIReport -Verbose
+            $datasources.GetType() | Should BeOfType System.Object
+            $datasources.DataSourceSubType | Should Be "DataModel"
+            $datasources.ConnectionString | Should Be "localhost;ReportServer"
+
+            $datasources = Get-RsRestDataModelDataSource -ReportPortalUri $reportPortalUri -RsItem $sqlPowerBIReport -Verbose
+
+
+            $TestResponse = Test-RsRestItemDataSource -ReportPortalUri $reportPortalUri -RsItem $sqlPowerBIReport -Verbose
+            $TestResponse.IsSuccessful | Should be "False"
+            $TestResponse.ErrorMessage | Should be "A user name wasn't specified"
+        }
+    }
+
+    Context "WebSession parameter" {
+        $rsSession = $null
+
+        BeforeEach {
+            $rsSession = New-RsRestSession -ReportPortalUri $reportPortalUri
+        }
+
+        It "fetches data sources for paginated reports" {
+            $datasources = Get-RsRestItemDataSource -WebSession $rsSession -RsItem $datasourcesReport -Verbose
+            $datasources.Count | Should Be 2
+            $datasources[0].DataSourceType | Should Be "SQL"
+            $datasources[0].DataSourceSubType | Should BeNullOrEmpty 
+            $datasources[0].ConnectionString | Should Be "Data Source=localhost;Initial Catalog=master"
+            $datasources[1].DataSourceType | Should Be "SQL"
+            $datasources[1].DataSourceSubType | Should BeNullOrEmpty
+            $datasources[1].ConnectionString | Should Be "Data Source=localhost;Initial Catalog=model"
+        }
+
+        It "fetches data sources for power bi reports" {
+            $datasources = Get-RsRestItemDataSource -WebSession $rsSession -RsItem $sqlPowerBIReport -Verbose
+            $datasources.GetType() | Should BeOfType System.Object
+            $datasources.DataSourceSubType | Should Be "DataModel"
+            $datasources.ConnectionString | Should Be "localhost;ReportServer"
+        }
+    }
+}


### PR DESCRIPTION
Changes proposed in this pull request:
 - Added Test-RsRestItemDataSource function found in Test-RsRestItemDataSource.ps1
 - Test-RsRestItemDataSource.Tests.ps1

How to test this code:
 - Use the pester test found in Test-RsRestItemDataSource.Tests.ps1

Has been tested on (remove any that don't apply):
 - PowerShell 7.1 and above
 - Windows 10
 - PBIRS
