### PR TITLE
Update Get-RsRestCacheRefreshPlanHistory.Tests.ps1

### DIFF
--- a/Tests/CatalogItems/Rest/Get-RsRestCacheRefreshPlanHistory.Tests.ps1
+++ b/Tests/CatalogItems/Rest/Get-RsRestCacheRefreshPlanHistory.Tests.ps1
@@ -62,10 +62,8 @@ Describe "Get-RsRestCacheRefreshPlanHistory" {
             $plan.LastStatus | Should Not Be 'New Scheduled Refresh Plan'
 
             $timer= get-date
-            while ($true) {
+            while ((@($someHistory).count -lt 1)) {
                 $someHistory = Get-RsRestCacheRefreshPlanHistory -ReportPortalUri $reportPortalUri -RsReport "$($rsFolderPath)/ReportCatalog"
-                if(@($someHistory).count -gt 0){ 
-                    break }
                 if(((get-date)-$timer).seconds -ge 15) {
                     break
                 }
@@ -74,10 +72,8 @@ Describe "Get-RsRestCacheRefreshPlanHistory" {
             
             Start-RsRestCacheRefreshPlan -ReportPortalUri $reportPortalUri -RsReport "$($rsFolderPath)/ReportCatalog"
             $timer= get-date
-            while ($true) {
+            while ((@($moreHistory).count -lt 2)) {
                 $moreHistory = Get-RsRestCacheRefreshPlanHistory -ReportPortalUri $reportPortalUri -RsReport "$($rsFolderPath)/ReportCatalog"
-                if(@($moreHistory).count -gt 1){ 
-                    break }
                 if(((get-date)-$timer).seconds -ge 15) {
                     break
                 }

--- a/Tests/CatalogItems/Rest/Get-RsRestCacheRefreshPlanHistory.Tests.ps1
+++ b/Tests/CatalogItems/Rest/Get-RsRestCacheRefreshPlanHistory.Tests.ps1
@@ -41,7 +41,7 @@ Describe "Get-RsRestCacheRefreshPlanHistory" {
 
         $dataSources = Get-RsRestItemDataSource -RsItem "$($rsFolderPath)/ReportCatalog" -ReportPortalUri $reportPortalUri
         $dataSources[0].DataModelDataSource.AuthType = 'UsernamePassword'
-        $dataSources[0].DataModelDataSource.Username = 'PBIRS3'
+        $dataSources[0].DataModelDataSource.Username = 'sa'
         $dataSources[0].DataModelDataSource.Secret = 'i<3ReportingServices'
         Set-RsRestItemDataSource -RsItem "$($rsFolderPath)/ReportCatalog" -ReportPortalUri $reportPortalUri -DataSources $dataSources -RsItemType 'PowerBIReport'
         New-RsRestCacheRefreshPlan -RsItem "$($rsFolderPath)/ReportCatalog" -ReportPortalUri $reportPortalUri -Description 'My New Refresh Plan' -Verbose
@@ -66,8 +66,15 @@ Describe "Get-RsRestCacheRefreshPlanHistory" {
             @($someHistory).count | Should be 1
             
             Start-RsRestCacheRefreshPlan -ReportPortalUri $reportPortalUri -RsReport "$($rsFolderPath)/ReportCatalog"
-            Start-Sleep -Seconds 6
-            $moreHistory = Get-RsRestCacheRefreshPlanHistory -ReportPortalUri $reportPortalUri -RsReport "$($rsFolderPath)/ReportCatalog"
+            $timer= get-date
+            while ($true) {
+                $moreHistory = Get-RsRestCacheRefreshPlanHistory -ReportPortalUri $reportPortalUri -RsReport "$($rsFolderPath)/ReportCatalog"
+                if(@($moreHistory).count -gt 1){ 
+                    break }
+                if(((get-date)-$timer).seconds -ge 15) {
+                    break
+                }
+            }
             @($moreHistory).count | Should be 2
         }
     }

--- a/Tests/CatalogItems/Rest/Get-RsRestCacheRefreshPlanHistory.Tests.ps1
+++ b/Tests/CatalogItems/Rest/Get-RsRestCacheRefreshPlanHistory.Tests.ps1
@@ -61,8 +61,15 @@ Describe "Get-RsRestCacheRefreshPlanHistory" {
             $plan | Should Not BeNullOrEmpty
             $plan.LastStatus | Should Not Be 'New Scheduled Refresh Plan'
 
-            Start-Sleep -Seconds 6
-            $someHistory = Get-RsRestCacheRefreshPlanHistory -ReportPortalUri $reportPortalUri -RsReport "$($rsFolderPath)/ReportCatalog"
+            $timer= get-date
+            while ($true) {
+                $someHistory = Get-RsRestCacheRefreshPlanHistory -ReportPortalUri $reportPortalUri -RsReport "$($rsFolderPath)/ReportCatalog"
+                if(@($someHistory).count -gt 0){ 
+                    break }
+                if(((get-date)-$timer).seconds -ge 15) {
+                    break
+                }
+            }            
             @($someHistory).count | Should be 1
             
             Start-RsRestCacheRefreshPlan -ReportPortalUri $reportPortalUri -RsReport "$($rsFolderPath)/ReportCatalog"

--- a/Tests/CatalogItems/Rest/Get-RsRestCacheRefreshPlanHistory.Tests.ps1
+++ b/Tests/CatalogItems/Rest/Get-RsRestCacheRefreshPlanHistory.Tests.ps1
@@ -32,7 +32,7 @@ Describe "Get-RsRestCacheRefreshPlanHistory" {
     $localPath =   (Get-Item -Path ".\").FullName  + '\Tests\CatalogItems\testResources'
 
     BeforeEach {
-        $folderName = 'SUT_WriteRsRestCatalogItem_' + [guid]::NewGuid()
+        $folderName = 'SUT_GetRsRestCacheRefreshPlanHistory_' + [guid]::NewGuid()
         New-RsRestFolder -ReportPortalUri $reportPortalUri -RsFolder / -FolderName $folderName -Verbose
         $rsFolderPath = '/' + $folderName
         $itemPath = $localPath + '\ReportCatalog.pbix'
@@ -61,12 +61,12 @@ Describe "Get-RsRestCacheRefreshPlanHistory" {
             $plan | Should Not BeNullOrEmpty
             $plan.LastStatus | Should Not Be 'New Scheduled Refresh Plan'
 
-            Start-Sleep -Seconds 3
+            Start-Sleep -Seconds 6
             $someHistory = Get-RsRestCacheRefreshPlanHistory -ReportPortalUri $reportPortalUri -RsReport "$($rsFolderPath)/ReportCatalog"
             @($someHistory).count | Should be 1
             
             Start-RsRestCacheRefreshPlan -ReportPortalUri $reportPortalUri -RsReport "$($rsFolderPath)/ReportCatalog"
-            Start-Sleep -Seconds 3
+            Start-Sleep -Seconds 6
             $moreHistory = Get-RsRestCacheRefreshPlanHistory -ReportPortalUri $reportPortalUri -RsReport "$($rsFolderPath)/ReportCatalog"
             @($moreHistory).count | Should be 2
         }


### PR DESCRIPTION
Changes proposed in this pull request:
 - Increased Start-Sleep duration from 3 seconds to 6 seconds, to allow time for subscription to run and have history to display.

How to test this code:
 - Run the test.

Has been tested on (remove any that don't apply):
 - PowerShell 7.1
 - Windows 10
 - PBIRS
