### PR TITLE
Adding NULL handling for target folders

### DIFF
--- a/ReportingServicesTools/Functions/CatalogItems/Get-RsDeploymentConfig.ps1
+++ b/ReportingServicesTools/Functions/CatalogItems/Get-RsDeploymentConfig.ps1
@@ -71,9 +71,9 @@ function Get-RsDeploymentConfig {
                 OverwriteDatasets      = $Deployment.OverwriteDatasets
                 OverwriteDataSources   = $Deployment.OverwriteDataSources
                 TargetReportFolder     = ($Deployment.TargetReportFolder).Trimend("/")
-                TargetDatasetFolder    = ($Deployment.TargetDatasetFolder).Trimend("/")
-                TargetDatasourceFolder = ($Deployment.TargetDatasourceFolder).Trimend("/")
-                TargetReportPartFolder = ($Deployment.TargetReportPartFolder).Trimend("/")
+                TargetDatasetFolder    = if ($null -eq $Deployment.TargetDatasetFolder) { $null } else { ($Deployment.TargetDatasetFolder).Trimend("/") }
+                TargetDatasourceFolder = if ($null -eq $Deployment.TargetDatasourceFolder) { $null } else { ($Deployment.TargetDatasourceFolder).Trimend("/") }
+                TargetReportPartFolder = if ($null -eq $Deployment.TargetReportPartFolder) { $null } else { ($Deployment.TargetReportPartFolder).Trimend("/") }
                 TargetServerURL        = $Deployment.TargetServerURL
                 RsProjectFolder        = Split-Path -Path $RsProjectFile
             }
@@ -89,9 +89,9 @@ function Get-RsDeploymentConfig {
                 OverwriteDatasets      = $Deployment.OverwriteDatasets
                 OverwriteDataSources   = $Deployment.OverwriteDataSources
                 TargetReportFolder     = ($Deployment.TargetReportFolder).Trimend("/")
-                TargetDatasetFolder    = ($Deployment.TargetDatasetFolder).Trimend("/")
-                TargetDatasourceFolder = ($Deployment.TargetDatasourceFolder).Trimend("/")
-                TargetReportPartFolder = ($Deployment.TargetReportPartFolder).Trimend("/")
+                TargetDatasetFolder    = if ($null -eq $Deployment.TargetDatasetFolder) { $null } else { ($Deployment.TargetDatasetFolder).Trimend("/") }
+                TargetDatasourceFolder = if ($null -eq $Deployment.TargetDatasourceFolder) { $null } else { ($Deployment.TargetDatasourceFolder).Trimend("/") }
+                TargetReportPartFolder = if ($null -eq $Deployment.TargetReportPartFolder) { $null } else { ($Deployment.TargetReportPartFolder).Trimend("/") }
                 TargetServerURL        = $Deployment.TargetServerURL
                 RsProjectFolder        = Split-Path -Path $RsProjectFile
             }

--- a/Tests/CatalogItems/Get-RsDeploymentConfig.Tests.ps1
+++ b/Tests/CatalogItems/Get-RsDeploymentConfig.Tests.ps1
@@ -4,17 +4,56 @@ Describe "Get-RsDeploymentConfig" {
     
     Write-Verbose "$RSConfig.TargetServerURL"
     Write-Verbose "$RSConfig.RsProjectFolder"
+    Write-Verbose "$RSConfig.TargetDatasetFolder"
+    Write-Verbose "$RSConfig.TargetDatasourceFolder"
+    Write-Verbose "$RSConfig.TargetReportPartFolder"
 
-    Context "Get the DeploymentConfig of a ReportServer project file using ConfigurationToUse parameter"{
-        # Create a folder
-        # Test if the config was found
+    Context "Get the Release DeploymentConfig of a ReportServer project file using ConfigurationToUse parameter"{
         It "Should verify TargetServerURL matches" {
             $RSConfig.TargetServerURL | Should Be 'http://localhost/reportserver'
         }
 
-        # Test if the folder can be found
         It "Should verify a config was retrieved" {
             @($RSConfig).Count | Should Be 1
+        }
+
+        It "Should verify the Dataset, Datasource, and ReportPart folders are NULL" {
+            #$RSConfig = Get-RsDeploymentConfig -RsProjectFile "$($PSScriptRoot)\TestProjects\SQLServerPerformanceDashboardReportingSolution\SQL Server Performance Dashboard\SQL Server Performance Dashboard.rptproj" -ConfigurationToUse Release
+            
+            Write-Verbose "$RSConfig.TargetDatasetFolder"
+            Write-Verbose "$RSConfig.TargetDatasourceFolder"
+            Write-Verbose "$RSConfig.TargetReportPartFolder"
+
+            $RSConfig.TargetDatasetFolder | Should Be '/Datasets'
+            $RSConfig.TargetDatasourceFolder | Should Be '/Data Sources'
+            $RSConfig.TargetReportPartFolder | Should Be 'Report Parts'
+        }
+        
+    }
+
+    Context "Get the DebugNull DeploymentConfig of a ReportServer project file using ConfigurationToUse parameter"{
+        It "Should verify TargetServerURL matches" {
+            $RSConfig = Get-RsDeploymentConfig -RsProjectFile "$($PSScriptRoot)\TestProjects\SQLServerPerformanceDashboardReportingSolution\SQL Server Performance Dashboard\SQL Server Performance Dashboard.rptproj" -ConfigurationToUse DebugNull
+            
+            Write-Verbose "$RSConfig.TargetServerURL"
+            Write-Verbose "$RSConfig.RsProjectFolder"
+            Write-Verbose "$RSConfig.TargetDatasetFolder"
+            Write-Verbose "$RSConfig.TargetDatasourceFolder"
+            Write-Verbose "$RSConfig.TargetReportPartFolder"
+
+            $RSConfig.TargetServerURL | Should Be 'http://localhost/reportserver'
+        }
+
+        It "Should verify a config was retrieved" {
+            @($RSConfig).Count | Should Be 1
+        }
+
+        It "Should verify config was successfully retrieved even though Dataset, Datasource, and ReportPart folders are NULL" {
+            $RSConfig = Get-RsDeploymentConfig -RsProjectFile "$($PSScriptRoot)\TestProjects\SQLServerPerformanceDashboardReportingSolution\SQL Server Performance Dashboard\SQL Server Performance Dashboard.rptproj" -ConfigurationToUse DebugNull
+            
+            $RSConfig.TargetDatasetFolder | Should BeNullOrEmpty
+            $RSConfig.TargetDatasourceFolder | Should BeNullOrEmpty
+            $RSConfig.TargetReportPartFolder | Should BeNullOrEmpty
         }
         
     }

--- a/Tests/CatalogItems/TestProjects/SQLServerPerformanceDashboardReportingSolution/SQL Server Performance Dashboard/SQL Server Performance Dashboard.rptproj
+++ b/Tests/CatalogItems/TestProjects/SQLServerPerformanceDashboardReportingSolution/SQL Server Performance Dashboard/SQL Server Performance Dashboard.rptproj
@@ -27,6 +27,20 @@
     <TargetDatasourceFolder>Data Sources</TargetDatasourceFolder>
     <TargetReportPartFolder>Report Parts</TargetReportPartFolder>
   </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)' == 'DebugNull' ">
+    <FullPath>DebugNull</FullPath>
+    <OutputPath>bin\DebugLocal</OutputPath>
+    <ErrorLevel>2</ErrorLevel>
+    <OverwriteDatasets>False</OverwriteDatasets>
+    <OverwriteDataSources>False</OverwriteDataSources>
+    <TargetServerVersion>SSRS2008R2</TargetServerVersion>
+    <Platform>Win32</Platform>
+    <TargetReportFolder>SQL Server Performance Dashboard</TargetReportFolder>
+    <TargetDatasetFolder></TargetDatasetFolder>
+    <TargetDatasourceFolder></TargetDatasourceFolder>
+    <TargetReportPartFolder></TargetReportPartFolder>
+    <TargetServerURL>http://localhost/reportserver</TargetServerURL>
+  </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)' == 'Release' ">
     <FullPath>Release</FullPath>
     <OutputPath>bin\Release</OutputPath>


### PR DESCRIPTION
Adding NULL handling for Dataset, Datasource, & ReportPart folders.

Fixes #319  .

Changes proposed in this pull request:
 - Added handling of NULL for Dataset, Datasource, & ReportPart folders proposed in #319

How to test this code:
 - Use the Pester test.

Has been tested on (remove any that don't apply):
 - PowerShell 5.1
 - Windows 10
 - PBIRS
