### PR TITLE
Removed the plural s from DataModelParameters

### DIFF
--- a/ReportingServicesTools/Functions/CatalogItems/Rest/Get-RsRestItemDataModelParameters.ps1
+++ b/ReportingServicesTools/Functions/CatalogItems/Rest/Get-RsRestItemDataModelParameters.ps1
@@ -1,7 +1,7 @@
 # Copyright (c) 2017 Microsoft Corporation. All Rights Reserved.
 # Licensed under the MIT License (MIT)
 
-function Get-RsRestItemDataModelParameters
+function Get-RsRestItemDataModelParameter
 {
     <#
         .SYNOPSIS
@@ -26,21 +26,21 @@ function Get-RsRestItemDataModelParameters
             Specify the session to be used when making calls to REST Endpoint.
 
         .EXAMPLE
-            Get-RsRestItemDataModelParameters -RsItem "/MyPbixReport1"
+            Get-RsRestItemDataModelParameter -RsItem "/MyPbixReport1"
 
             Description
             -----------
             Fetches data model parameter information associated to "MyReport" catalog item found in "/" folder from the Report Server located at http://localhost/reports.
 
         .EXAMPLE
-            Get-RsRestItemDataModelParameters -RsItem "/MyReport" -WebSession $session
+            Get-RsRestItemDataModelParameter -RsItem "/MyReport" -WebSession $session
 
             Description
             -----------
             Fetches data model parameter information associated to "MyReport" catalog item found in "/" folder from the Report Server located at specificed WebSession object.
 
         .EXAMPLE
-            Get-RsRestItemDataModelParameters -RsItem "/MyReport" -ReportPortalUri http://myserver/reports
+            Get-RsRestItemDataModelParameter -RsItem "/MyReport" -ReportPortalUri http://myserver/reports
 
             Description
             -----------
@@ -117,3 +117,4 @@ function Get-RsRestItemDataModelParameters
         }
     }
 }
+New-Alias -Name "Get-RsRestItemDataModelParameters" -Value Get-RsRestItemDataModelParameter -Scope Global

--- a/ReportingServicesTools/Functions/CatalogItems/Rest/Set-RsRestItemDataModelParameters.ps1
+++ b/ReportingServicesTools/Functions/CatalogItems/Rest/Set-RsRestItemDataModelParameters.ps1
@@ -1,7 +1,7 @@
 # Copyright (c) 2017 Microsoft Corporation. All Rights Reserved.
 # Licensed under the MIT License (MIT)
 
-function Set-RsRestItemDataModelParameters
+function Set-RsRestItemDataModelParameter
 {
     <#
         .SYNOPSIS
@@ -31,7 +31,7 @@ function Set-RsRestItemDataModelParameters
         .EXAMPLE
             $parameters = Get-RsRestItemDataModelParameters -RsItem '/MyPowerBIReport'
             $parameters[0].Value = 'NewValue'
-            Set-RsRestItemDataModelParameters -RsItem '/MyPowerBIReport' -DataModelParameters $parameters
+            Set-RsRestItemDataModelParameter -RsItem '/MyPowerBIReport' -DataModelParameters $parameters
 
             Description
             -----------
@@ -107,3 +107,4 @@ function Set-RsRestItemDataModelParameters
         }
     }
 }
+New-Alias -Name "Set-RsRestItemDataModelParameters" -Value Set-RsRestItemDataModelParameter -Scope Global

--- a/ReportingServicesTools/ReportingServicesTools.psd1
+++ b/ReportingServicesTools/ReportingServicesTools.psd1
@@ -76,7 +76,7 @@
         'Get-RsRestCacheRefreshPlan',
         'Get-RsRestCacheRefreshPlanHistory',
         'Get-RsRestItemDataSource',
-        'Get-RsRestItemDataModelParameters',
+        'Get-RsRestItemDataModelParameter',
         'Get-RsRestItem',
         'Get-RsRestItemAccessPolicy',
         'Get-RsSubscription',
@@ -118,7 +118,7 @@
         'Set-RsDataSourceReference',
         'Set-RsEmailSettings',
         'Set-RsItemDataSource',
-        'Set-RsRestItemDataModelParameters';
+        'Set-RsRestItemDataModelParameter';
         'Set-RsRestItemDataSource',
         'Set-RsSubscription',
         'Set-RsUrlReservation',

--- a/Tests/CatalogItems/Rest/Get-RsRestItemDataModelParameters.Tests.ps1
+++ b/Tests/CatalogItems/Rest/Get-RsRestItemDataModelParameters.Tests.ps1
@@ -3,7 +3,7 @@
 
 $reportPortalUri = if ($env:PesterPortalUrl -eq $null) { 'http://localhost/reports' } else { $env:PesterPortalUrl }
 
-Describe "Get-RsRestItemDataModelParameters" {
+Describe "Get-RsRestItemDataModelParameter" {
     $session = $null
     $rsFolderPath = ""
     $sqlPowerBIReport = ""
@@ -30,7 +30,7 @@ Describe "Get-RsRestItemDataModelParameters" {
 
     Context "ReportPortalUri parameter" {
         It "fetches parameters for power bi reports" {
-            $dataModelParameters = Get-RsRestItemDataModelParameters -ReportPortalUri $reportPortalUri -RsItem $sqlPowerBIReport -Verbose
+            $dataModelParameters = Get-RsRestItemDataModelParameter -ReportPortalUri $reportPortalUri -RsItem $sqlPowerBIReport -Verbose
             $dataModelParameters[0].Name | Should Be "Databasename"
             $dataModelParameters[0].Value | Should Be "ReportServer_2019"
         }
@@ -44,7 +44,7 @@ Describe "Get-RsRestItemDataModelParameters" {
         }
 
         It "fetches data sources for power bi reports" {
-            $dataModelParameters = Get-RsRestItemDataModelParameters -WebSession $rsSession -RsItem $sqlPowerBIReport -Verbose
+            $dataModelParameters = Get-RsRestItemDataModelParameter -WebSession $rsSession -RsItem $sqlPowerBIReport -Verbose
             $dataModelParameters[0].Name | Should Be "Databasename"
             $dataModelParameters[0].Value | Should Be "ReportServer_2019"
         }

--- a/Tests/CatalogItems/Rest/Set-RsRestItemDataModelParameters.Tests.ps1
+++ b/Tests/CatalogItems/Rest/Set-RsRestItemDataModelParameters.Tests.ps1
@@ -3,7 +3,7 @@
 
 $reportPortalUri = if ($env:PesterPortalUrl -eq $null) { 'http://localhost/reports' } else { $env:PesterPortalUrl }
 
-Describe "Set-RsRestItemDataModelParameters" {
+Describe "Set-RsRestItemDataModelParameter" {
     $session = $null
     $rsFolderPath = ""
     $sqlPowerBIReport = ""
@@ -30,12 +30,12 @@ Describe "Set-RsRestItemDataModelParameters" {
 
     Context "ReportPortalUri parameter" {
         It "fetches parameters for power bi reports" {
-            $dataModelParameters = Get-RsRestItemDataModelParameters -ReportPortalUri $reportPortalUri -RsItem $sqlPowerBIReport -Verbose            
+            $dataModelParameters = Get-RsRestItemDataModelParameter -ReportPortalUri $reportPortalUri -RsItem $sqlPowerBIReport -Verbose            
             $dataModelParameters[0].Value = "NewValue"
 
-            Set-RsRestItemDataModelParameters -ReportPortalUri $reportPortalUri -RsItem $sqlPowerBIReport -DataModelParameters $dataModelParameters -Verbose
+            Set-RsRestItemDataModelParameter -ReportPortalUri $reportPortalUri -RsItem $sqlPowerBIReport -DataModelParameters $dataModelParameters -Verbose
 
-            $dataModelParameters = Get-RsRestItemDataModelParameters -ReportPortalUri $reportPortalUri -RsItem $sqlPowerBIReport -Verbose            
+            $dataModelParameters = Get-RsRestItemDataModelParameter -ReportPortalUri $reportPortalUri -RsItem $sqlPowerBIReport -Verbose            
             $dataModelParameters[0].Value | Should Be "NewValue"            
         }
     }
@@ -48,12 +48,12 @@ Describe "Set-RsRestItemDataModelParameters" {
         }
 
         It "fetches data sources for power bi reports" {
-            $dataModelParameters = Get-RsRestItemDataModelParameters -WebSession $rsSession -RsItem $sqlPowerBIReport -Verbose
+            $dataModelParameters = Get-RsRestItemDataModelParameter -WebSession $rsSession -RsItem $sqlPowerBIReport -Verbose
             $dataModelParameters[0].Value = "NewValue"
 
-            Set-RsRestItemDataModelParameters -WebSession $rsSession -RsItem $sqlPowerBIReport -DataModelParameters $dataModelParameters -Verbose
+            Set-RsRestItemDataModelParameter -WebSession $rsSession -RsItem $sqlPowerBIReport -DataModelParameters $dataModelParameters -Verbose
 
-            $dataModelParameters = Get-RsRestItemDataModelParameters -WebSession $rsSession -RsItem $sqlPowerBIReport -Verbose            
+            $dataModelParameters = Get-RsRestItemDataModelParameter -WebSession $rsSession -RsItem $sqlPowerBIReport -Verbose            
             $dataModelParameters[0].Value | Should Be "NewValue" 
         }
     }


### PR DESCRIPTION
Removed the plural s from DataModelParameters from the Get-RsRestItemDataModelParameters & Set-RsRestItemDataModelParameters functions, to meet the PowerShell naming standard.

Changes proposed in this pull request:
 - Removed the plural s from the Get-RsRestItemDataModelParameters function, added an alias.
 - Removed the plural s from the Set-RsRestItemDataModelParameters function, added an alias.
 - Updated the corresponding tests as well.

How to test this code:
 - Run the updated Pester tests.

Has been tested on (remove any that don't apply):
 - PowerShell 7.1
 - Windows 10
 - PBIRS
