### PR TITLE
Update SSRS Service name for newer versions

### DIFF
--- a/ReportingServicesTools/Functions/Admin/Restore-RsEncryptionKey.ps1
+++ b/ReportingServicesTools/Functions/Admin/Restore-RsEncryptionKey.ps1
@@ -81,9 +81,13 @@ function Restore-RSEncryptionKey
 
         if ($rsWmiObject.InstanceName -ne "MSSQLSERVER")
         {
-            if($rsWmiObject.InstanceName -eq "PBIRS")
+            if ($rsWmiObject.InstanceName -eq "PBIRS")
             {
                 $reportServerService = 'PowerBIReportServer'
+            }
+            elseif ($rsWmiObject.InstanceName -eq "SSRS")
+            {
+                $reportServerService = 'SQLServerReportingServices'
             }
             else
             {


### PR DESCRIPTION
Fixes #159 .

Changes proposed in this pull request:
 - Change service name if SSRS (default for newer versions) is the  Instance Name

How to test this code:
 - Restore-RsEncryptionKey -ComputerName Name -ReportServerVersion 15 -ReportServerInstance SSRS -Password 'Pass' -KeyPath 'C:\Folder\File.snk'

Has been tested on (remove any that don't apply):
 - Powershell 5 and above
 - Windows 10 and above
 - SQL Server 2019 and above
