### PR TITLE
Specify the UseBasicParsing parameter when using Invoke-WebRequest to…

### DIFF
--- a/ReportingServicesTools/Functions/Utilities/New-RsRestSession.ps1
+++ b/ReportingServicesTools/Functions/Utilities/New-RsRestSession.ps1
@@ -71,11 +71,11 @@ function New-RsRestSession
         Write-Verbose "Making call to $meUri to create a session..."
         if ($Credential)
         {
-            $result = Invoke-WebRequest -Uri $meUri -Credential $Credential -SessionVariable mySession -Verbose:$false -ErrorAction Stop
+            $result = Invoke-WebRequest -Uri $meUri -Credential $Credential -SessionVariable mySession -UseBasicParsing -Verbose:$false -ErrorAction Stop
         }
         else
         {
-            $result = Invoke-WebRequest -Uri $meUri -UseDefaultCredentials -SessionVariable mySession -Verbose:$false -ErrorAction Stop
+            $result = Invoke-WebRequest -Uri $meUri -UseDefaultCredentials -SessionVariable mySession -UseBasicParsing -Verbose:$false -ErrorAction Stop
         }
 
         if ($result.StatusCode -ne 200)


### PR DESCRIPTION
… avoid error

Fixes # .

Changes proposed in this pull request:
 - When calling Remove-RsRestFolder I got the following error: Failed to create a new session to http://ddprod03.dedata.com.au/ReportServer/api/v2.0/me : The response content cannot be parsed because the Internet Explorer engine is not available, or Internet Explorer's 
first-launch configuration is not complete. Specify the UseBasicParsing parameter and try again.
 - Add the UseBasicParsing parameter in the New-RsRestSession function

How to test this code:
 - Not sure how to test this in addition more that the existing tests should pass

Has been tested on (remove any that don't apply):
 - Powershell 5.1
 - Windows 10 20H2
 - SQL Server 2017
