### PR TITLE
Add function to remove Scheduled Refresh from a PBIX report

### DIFF
--- a/ReportingServicesTools/Functions/CatalogItems/Rest/Remove-RsRestCacheRefreshPlan.ps1
+++ b/ReportingServicesTools/Functions/CatalogItems/Rest/Remove-RsRestCacheRefreshPlan.ps1
@@ -1,0 +1,125 @@
+# Copyright (c) 2020 Microsoft Corporation. All Rights Reserved.
+# Licensed under the MIT License (MIT)
+
+function Remove-RsRestCacheRefreshPlan {
+    <#
+        .SYNOPSIS
+            This function deletes a CacheRefreshPlan from a report from the Report Server.
+        .DESCRIPTION
+            This function deletes a CacheRefreshPlan of a report from the Report Server using 
+            the REST API.  Alternatively, when a report has multiple CacheRefreshPlans you can specify which 
+            CacheRefreshPlan to delete by passing the Id of the CacheRefreshPlan to the -Id parameter.
+        .PARAMETER RsReport
+            Specify the location of the report which should have its CacheRefreshPlans deleted.
+        .PARAMETER Id
+            Specify the Id of the CacheRefreshPlan to delete.
+        .PARAMETER ReportPortalUri
+            Specify the Report Portal URL to your SQL Server Reporting Services Instance or Power BI Report Server Instance.
+        .PARAMETER RestApiVersion
+            Specify the version of REST Endpoint to use. Valid values are: "v2.0".
+        .PARAMETER Credential
+            Specify the credentials to use when connecting to the Report Server.
+        .PARAMETER WebSession
+            Specify the session to be used when making calls to REST Endpoint.
+
+        .EXAMPLE
+            Remove-RsCacheRefreshPlan -RsReport '/MyReport' 
+
+            Description
+            -----------
+            Fetches the CacheRefreshPlan of a report named "MyReport" found in "/" folder from the Report Server located at http://localhost/reports, 
+            and deletes it.
+            NOTE: This only works when the report has a single CacheRefreshPlan.
+
+        .EXAMPLE
+            $scheduleID = (Get-RsCacheRefreshPlan -RsReport '/MyReport').ID[0]
+            Remove-RsCacheRefreshPlan -ID $scheduleID
+
+            Description
+            -----------
+            Fetches the CacheRefreshPlan of a report named "MyReport" found in "/" folder from the Report Server and gets the ID of the first Schedule 
+            refresh (when multiple are present), then deletes it.
+    #>
+
+    [CmdletBinding(SupportsShouldProcess = $true, ConfirmImpact = 'Medium')]
+    param(
+        [Parameter(Mandatory = $false, ValueFromPipelineByPropertyName = $true)]
+        [Alias('ItemPath','Path', 'RsItem')]
+        [string]
+        $RsReport,
+
+        [Parameter(Mandatory = $false, ValueFromPipelineByPropertyName = $true)]
+        [Alias('CacheRefreshPlan')]
+        [string]
+        $Id = $null,
+
+        [Parameter(Mandatory = $false, ValueFromPipelineByPropertyName = $true)]
+        [string]
+        $ReportPortalUri,
+
+        [Alias('ApiVersion')]
+        [ValidateSet("v2.0")]
+        [string]
+        $RestApiVersion = "v2.0",
+
+        [Alias('ReportServerCredentials')]
+        [System.Management.Automation.PSCredential]
+        $Credential,
+
+        [Microsoft.PowerShell.Commands.WebRequestSession]
+        $WebSession
+    )
+    Begin
+    {
+        $WebSession = New-RsRestSessionHelper -BoundParameters $PSBoundParameters
+        $ReportPortalUri = Get-RsPortalUriHelper -WebSession $WebSession
+        $CacheRefreshPlansUri = $ReportPortalUri + "api/$RestApiVersion/CacheRefreshPlans({0})"
+    }
+    Process
+    {
+        try
+        {
+            if (-not $RsReport)
+            {
+                Write-Verbose "Fetching CacheRefreshPlans for Id $Id..."
+                $CacheRefreshPlansUri = [String]::Format($CacheRefreshPlansUri, $Id)
+            }
+            else
+            {
+                Write-Verbose "Fetching CacheRefreshPlans for $RsReport..."
+                if ($Credential -ne $null)
+                {
+                    $RefreshPlan = Get-RsCacheRefreshPlan -ReportPortalUri $ReportPortalUri -RsReport $RsReport -WebSession $WebSession -Credential $Credential -Verbose:$false
+                }
+                else
+                {
+                    $RefreshPlan = Get-RsCacheRefreshPlan -ReportPortalUri $ReportPortalUri -RsReport $RsReport -WebSession $WebSession -Verbose:$false
+                }
+                if ($RefreshPlan.Count -le 1)
+                {
+                    $CacheRefreshPlansUri = [String]::Format($CacheRefreshPlansUri, $RefreshPlan.Id)
+                }
+                else 
+                {
+                    Write-Warning "Unable to delete scheduled refresh for $RsReport because multiple CacheRefreshPlans are present."
+                }
+            }
+            Write-Verbose "$($CacheRefreshPlansUri)"
+            
+            Write-Verbose "Deleting $($RefreshPlan.RsReport)$($Id)..."
+            if ($Credential -ne $null)
+            {
+                $response = Invoke-RestMethod -Uri $CacheRefreshPlansUri -Method Delete -WebSession $WebSession -Credential $Credential -Verbose:$false
+            }
+            else
+            {
+                $response = Invoke-RestMethod -Uri $CacheRefreshPlansUri -Method Delete -WebSession $WebSession -UseDefaultCredentials -Verbose:$false
+            }
+        }
+        catch
+        {
+            throw (New-Object System.Exception("Unable to delete '$($RefreshPlan.RsReport)'  '$($Id)': $($_.Exception.Message)", $_.Exception))
+        }
+    }
+}
+New-Alias -Name "Remove-RsPbiReportRefresh" -Value Remove-RsRestCacheRefreshPlan -Scope Global

--- a/ReportingServicesTools/Functions/CatalogItems/Rest/Remove-RsRestCacheRefreshPlan.ps1
+++ b/ReportingServicesTools/Functions/CatalogItems/Rest/Remove-RsRestCacheRefreshPlan.ps1
@@ -6,7 +6,7 @@ function Remove-RsRestCacheRefreshPlan {
         .SYNOPSIS
             This function deletes a CacheRefreshPlan from a report from the Report Server.
         .DESCRIPTION
-            This function deletes a CacheRefreshPlan of a report from the Report Server using 
+            This function deletes a CacheRefreshPlan from a report from the Report Server using 
             the REST API.  Alternatively, when a report has multiple CacheRefreshPlans you can specify which 
             CacheRefreshPlan to delete by passing the Id of the CacheRefreshPlan to the -Id parameter.
         .PARAMETER RsReport

--- a/ReportingServicesTools/ReportingServicesTools.psd1
+++ b/ReportingServicesTools/ReportingServicesTools.psd1
@@ -106,6 +106,7 @@
         'Remove-RsRestFolder',
         'Remove-RsRestCatalogItem',
         'Remove-RsSubscription',
+        'Remove-RsRestCacheRefreshPlan',
         'Restore-RsEncryptionKey',
         'Revoke-RsCatalogItemAccess',
         'Revoke-RsRestItemAccessPolicy',

--- a/Tests/CatalogItems/Rest/Remove-RsRestCacheRefreshPlan.Tests.ps1
+++ b/Tests/CatalogItems/Rest/Remove-RsRestCacheRefreshPlan.Tests.ps1
@@ -1,0 +1,64 @@
+# Copyright (c) 2021 Microsoft Corporation. All Rights Reserved.
+# Licensed under the MIT License (MIT)
+
+$reportPortalUri = if ($env:PesterPortalUrl -eq $null) { 'http://localhost/reports' } else { $env:PesterPortalUrl }
+$reportServerUri = if ($env:PesterServerUrl -eq $null) { 'http://localhost/reportserver' } else { $env:PesterServerUrl }
+
+function VerifyCatalogItemExists()
+{
+    param(
+        [Parameter(Mandatory = $True)]
+        [string]
+        $itemName,
+
+        [Parameter(Mandatory = $True)]
+        [string]
+        $itemType,
+
+        [Parameter(Mandatory = $True)]
+        [string]
+        $folderPath,
+
+        [string]
+        $reportPortalUri
+    )
+
+    $item = (Get-RsRestItem -reportPortalUri $reportPortalUri -RsItem "$($folderPath)/$($itemName)" ) | Where-Object { $_.Type -eq $itemType -and $_.Name -eq $itemName }
+    $item | Should Not BeNullOrEmpty
+}
+
+Describe "Remove-RsRestCacheRefreshPlan" {
+    $rsFolderPath = ""
+    $localPath =   (Get-Item -Path ".\").FullName  + '\Tests\CatalogItems\testResources'
+
+    BeforeEach {
+        $folderName = 'SUT_WriteRsRestCatalogItem_' + [guid]::NewGuid()
+        New-RsRestFolder -ReportPortalUri $reportPortalUri -RsFolder / -FolderName $folderName -Verbose
+        $rsFolderPath = '/' + $folderName
+        $itemPath = $localPath + '\ReportCatalog.pbix'
+        Write-RsRestCatalogItem -ReportPortalUri $reportPortalUri -Path $itemPath -RsFolder $rsFolderPath -Verbose
+        VerifyCatalogItemExists -itemName 'ReportCatalog' -itemType 'PowerBIReport' -folderPath $rsFolderPath -reportPortalUri $reportPortalUri
+
+        $dataSources = Get-RsRestItemDataSource -RsItem "$($rsFolderPath)/ReportCatalog" -ReportPortalUri $reportPortalUri
+        $dataSources[0].DataModelDataSource.AuthType = 'UsernamePassword'
+        $dataSources[0].DataModelDataSource.Username = 'PBIRS'
+        $dataSources[0].DataModelDataSource.Secret = 'password'
+        Set-RsRestItemDataSource -RsItem "$($rsFolderPath)/ReportCatalog" -ReportPortalUri $reportPortalUri -DataSources $dataSources -RsItemType 'PowerBIReport'
+        New-RsRestCacheRefreshPlan -RsItem "$($rsFolderPath)/ReportCatalog" -ReportPortalUri $reportPortalUri -Description 'My New Refresh Plan' -Verbose
+
+    }
+
+    AfterEach {
+        Remove-RsRestCatalogItem -ReportPortalUri $reportPortalUri -RsItem $rsFolderPath -Confirm:$false
+    }
+
+    Context "ReportPortalUri parameter" {
+        
+        It "Should remove a CacheRefreshPlan plan for a PBIX report" {
+            Remove-RsRestCacheRefreshPlan -ReportPortalUri $reportPortalUri -RsReport "$($rsFolderPath)/ReportCatalog"
+
+            $plan = Get-RsCacheRefreshPlan -ReportPortalUri $reportPortalUri -RsReport "$($rsFolderPath)/ReportCatalog"
+            $plan | Should BeNullOrEmpty
+        }
+    }
+}


### PR DESCRIPTION
Added function to remove scheduled refresh (CacheRefeshPlan) from a PBIX file to complement the existing Get, Create, Start functions for scheduled refresh.

Changes proposed in this pull request:
 - Add function to delete scheduled refresh (CacheRefreshPlan)

How to test this code:
 - Run Remove-RsCacheRefreshPlan -RsReport '/MyReport' . Note that this works if there is only ONE scheduled refresh
 - Run Remove-RsCacheRefreshPlan -ID $scheduleID to delete a specific scheduled refresh using the schedule ID
      -To get an id, run $scheduleID = (Get-RsCacheRefreshPlan -RsReport '/MyReport').ID[0] 

Has been tested on :
- PowerShell 5
- Windows 10
- Windows Server 2016
