### PR TITLE
Implement -force switch

### DIFF
--- a/ReportingServicesTools/Functions/Admin/Backup-RsEncryptionKey.ps1
+++ b/ReportingServicesTools/Functions/Admin/Backup-RsEncryptionKey.ps1
@@ -75,9 +75,16 @@ function Backup-RsEncryptionKey
         $ComputerName,
         
         [System.Management.Automation.PSCredential]
-        $Credential
+        $Credential,
+
+        [Switch]
+        $Force
     )
     
+    if ($Force){
+        $ConfirmPreference = 'None'
+    }
+
     if ($PSCmdlet.ShouldProcess((Get-ShouldProcessTargetWmi -BoundParameters $PSBoundParameters), "Retrieve encryption key and create backup in $KeyPath"))
     {
         $rsWmiObject = New-RsConfigurationSettingObjectHelper -BoundParameters $PSBoundParameters

--- a/ReportingServicesTools/Functions/Admin/Register-RsPowerBI.ps1
+++ b/ReportingServicesTools/Functions/Admin/Register-RsPowerBI.ps1
@@ -114,8 +114,15 @@ function Register-RsPowerBI
         $ComputerName,
         
         [System.Management.Automation.PSCredential]
-        $Credential
+        $Credential,
+
+        [switch]
+        $Force
     )
+
+    if ($Force){
+        $ConfirmPreference = 'None'
+    }
     
     if ($PSCmdlet.ShouldProcess((Get-ShouldProcessTargetWmi -BoundParameters $PSBoundParameters), "Registering PowerBI for SQL Server Instance"))
     {

--- a/ReportingServicesTools/Functions/Admin/Restore-RsEncryptionKey.ps1
+++ b/ReportingServicesTools/Functions/Admin/Restore-RsEncryptionKey.ps1
@@ -68,8 +68,15 @@ function Restore-RSEncryptionKey
         $ComputerName,
 
         [System.Management.Automation.PSCredential]
-        $Credential
+        $Credential,
+
+        [switch]
+        $Force
     )
+
+    if ($Force){
+        $ConfirmPreference = 'None'
+    }
 
     if ($PSCmdlet.ShouldProcess((Get-ShouldProcessTargetWmi -BoundParameters $PSBoundParameters), "Restore encryptionkey from file $KeyPath"))
     {

--- a/ReportingServicesTools/Functions/Admin/Set-RsDatabase.ps1
+++ b/ReportingServicesTools/Functions/Admin/Set-RsDatabase.ps1
@@ -126,8 +126,15 @@ function Set-RsDatabase
         $Credential,
 
         [int]
-        $QueryTimeout = 30
+        $QueryTimeout = 30,
+
+        [switch]
+        $Force
     )
+
+    if ($Force){
+        $ConfirmPreference = 'None'
+    }
 
     if ($PSCmdlet.ShouldProcess((Get-ShouldProcessTargetWmi -BoundParameters $PSBoundParameters), "Configure to use $DatabaseServerName as database, using $DatabaseCredentialType runtime authentication and $AdminDatabaseCredentialType setup authentication"))
     {

--- a/ReportingServicesTools/Functions/Admin/Set-RsDatabaseCredentials.ps1
+++ b/ReportingServicesTools/Functions/Admin/Set-RsDatabaseCredentials.ps1
@@ -85,8 +85,15 @@ function Set-RsDatabaseCredentials
         $Credential,
 
         [int]
-        $QueryTimeout = 30
+        $QueryTimeout = 30,
+
+        [switch]
+        $Force
     )
+
+    if ($Force){
+        $ConfirmPreference = 'None'
+    }
 
     if ($PSCmdlet.ShouldProcess((Get-ShouldProcessTargetWmi -BoundParameters $PSBoundParameters), "Configure to use $DatabaseCredentialType authentication"))
     {

--- a/ReportingServicesTools/Functions/CatalogItems/Copy-RsSubscription.ps1
+++ b/ReportingServicesTools/Functions/CatalogItems/Copy-RsSubscription.ps1
@@ -102,7 +102,10 @@ function Copy-RsSubscription
 
         [parameter(Mandatory = $False)]
         [System.Boolean]
-        $SkipOwner = $False
+        $SkipOwner = $False,
+
+        [switch]
+        $Force
     )
     Begin
     {
@@ -125,6 +128,10 @@ function Copy-RsSubscription
     {
         try
         {
+            if ($Force) {
+                $ConfirmPreference = 'None'
+            }
+
             foreach ($sub in $Subscription)
             {
                 if ($RsFolder)

--- a/ReportingServicesTools/Functions/CatalogItems/Export-RsSubscriptionXml.ps1
+++ b/ReportingServicesTools/Functions/CatalogItems/Export-RsSubscriptionXml.ps1
@@ -34,7 +34,10 @@ function Export-RsSubscriptionXml {
 
         [Parameter(Mandatory = $True, ValueFromPipeline=$true)]
         [object]
-        $Subscription
+        $Subscription,
+
+        [switch]
+        $Force
     )
 
     Begin {
@@ -44,6 +47,10 @@ function Export-RsSubscriptionXml {
         $Subscriptions = $Subscriptions + $Subscription
     }
     End {
+        
+        if ($Force) {
+            $ConfirmPreference = 'None'
+        }
         
         if ($PSCmdlet.ShouldProcess($Path, "Exporting subscriptions")) 
         {

--- a/ReportingServicesTools/Functions/CatalogItems/New-RsSubscription.ps1
+++ b/ReportingServicesTools/Functions/CatalogItems/New-RsSubscription.ps1
@@ -230,7 +230,10 @@ function New-RsSubscription
         [Parameter(ParameterSetName='FileShare')]
         [ValidateSet('None','Overwrite','AutoIncrement')]
         [string]
-        $FileWriteMode = 'Overwrite'
+        $FileWriteMode = 'Overwrite',
+
+        [switch]
+        $Force
     )
 
     Begin
@@ -239,6 +242,10 @@ function New-RsSubscription
     }
     Process
     {
+        if ($Force) {
+            $ConfirmPreference = 'None'
+        }
+
         if ([System.String]::IsNullOrEmpty($RsItem))
         {
             throw 'No report path was specified! You need to specify -RsItem variable.'

--- a/ReportingServicesTools/Functions/CatalogItems/Remove-RsCatalogItem.ps1
+++ b/ReportingServicesTools/Functions/CatalogItems/Remove-RsCatalogItem.ps1
@@ -57,7 +57,10 @@ function Remove-RsCatalogItem
         [System.Management.Automation.PSCredential]
         $Credential,
 
-        $Proxy
+        $Proxy,
+
+        [switch]
+        $Force
     )
     
     Begin
@@ -67,6 +70,10 @@ function Remove-RsCatalogItem
     
     Process
     {
+        if ($Force) {
+            $ConfirmPreference = 'None'
+        }
+
         foreach ($item in $RsItem)
         {
             if ($PSCmdlet.ShouldProcess($item, "Delete the catalog item"))

--- a/ReportingServicesTools/Functions/CatalogItems/Remove-RsSubscription.ps1
+++ b/ReportingServicesTools/Functions/CatalogItems/Remove-RsSubscription.ps1
@@ -72,7 +72,10 @@ function Remove-RsSubscription
         [System.Management.Automation.PSCredential]
         $Credential,
 
-        $Proxy
+        $Proxy,
+
+        [switch]
+        $Force
     )
     Begin
     {
@@ -80,6 +83,10 @@ function Remove-RsSubscription
     }
     Process
     {
+        if ($Force) {
+            $ConfirmPreference = 'None'
+        }
+
         if ([System.String]::IsNullOrEmpty($SubscriptionId)) 
         {
             foreach ($item in $Subscription)

--- a/ReportingServicesTools/Functions/CatalogItems/Rest/Remove-RsRestCatalogItem.ps1
+++ b/ReportingServicesTools/Functions/CatalogItems/Rest/Remove-RsRestCatalogItem.ps1
@@ -52,7 +52,10 @@ function Remove-RsRestCatalogItem
         $Credential,
 
         [Microsoft.PowerShell.Commands.WebRequestSession]
-        $WebSession
+        $WebSession,
+
+        [switch]
+        $Force
     )
     Begin
     {
@@ -62,6 +65,10 @@ function Remove-RsRestCatalogItem
     }
     Process
     {
+        if ($Force) {
+            $ConfirmPreference = 'None'
+        }
+
         if ($RsItem -eq '/')
         {
             throw "Root folder cannot be deleted!"

--- a/ReportingServicesTools/Functions/CatalogItems/Rest/Remove-RsRestFolder.ps1
+++ b/ReportingServicesTools/Functions/CatalogItems/Rest/Remove-RsRestFolder.ps1
@@ -52,7 +52,10 @@ function Remove-RsRestFolder
         $Credential,
 
         [Microsoft.PowerShell.Commands.WebRequestSession]
-        $WebSession
+        $WebSession,
+
+        [switch]
+        $Force
     )
     Begin
     {
@@ -62,6 +65,10 @@ function Remove-RsRestFolder
     }
     Process
     {
+        if ($Force) {
+            $ConfirmPreference = 'None'
+        }
+        
         if ($RsFolder -eq '/')
         {
             throw "Root folder cannot be deleted!"

--- a/ReportingServicesTools/Functions/CatalogItems/Rest/Set-RsRestItemDataModelParameters.ps1
+++ b/ReportingServicesTools/Functions/CatalogItems/Rest/Set-RsRestItemDataModelParameters.ps1
@@ -61,7 +61,10 @@ function Set-RsRestItemDataModelParameters
         $Credential,
 
         [Microsoft.PowerShell.Commands.WebRequestSession]
-        $WebSession
+        $WebSession,
+
+        [switch]
+        $Force
     )
     Begin
     {
@@ -71,6 +74,10 @@ function Set-RsRestItemDataModelParameters
     }
     Process
     {
+        if ($Force) {
+            $ConfirmPreference = 'None'
+        }
+
         try
         {          
             $dataModelParametersUri = [String]::Format($dataModelParametersUri, $RsItem)

--- a/ReportingServicesTools/Functions/CatalogItems/Rest/Set-RsRestItemDataSource.ps1
+++ b/ReportingServicesTools/Functions/CatalogItems/Rest/Set-RsRestItemDataSource.ps1
@@ -133,7 +133,10 @@ function Set-RsRestItemDataSource
         $Credential,
 
         [Microsoft.PowerShell.Commands.WebRequestSession]
-        $WebSession
+        $WebSession,
+
+        [switch]
+        $Force
     )
     Begin
     {
@@ -143,6 +146,10 @@ function Set-RsRestItemDataSource
     }
     Process
     {
+        if ($Force) {
+            $ConfirmPreference = 'None'
+        }
+
         try
         {
             # Basic DataSource Validation - Start

--- a/ReportingServicesTools/Functions/CatalogItems/Set-RsDataSetReference.ps1
+++ b/ReportingServicesTools/Functions/CatalogItems/Set-RsDataSetReference.ps1
@@ -62,7 +62,10 @@ function Set-RsDataSetReference
         [System.Management.Automation.PSCredential]
         $Credential,
         
-        $Proxy
+        $Proxy,
+
+        [switch]
+        $Force
     )
     
     Begin
@@ -72,6 +75,10 @@ function Set-RsDataSetReference
     
     Process
     {
+        if ($Force) {
+            $ConfirmPreference = 'None'
+        }
+
         foreach ($item in $Path)
         {
             #region Process each path passed

--- a/ReportingServicesTools/Functions/CatalogItems/Set-RsDataSource.ps1
+++ b/ReportingServicesTools/Functions/CatalogItems/Set-RsDataSource.ps1
@@ -53,7 +53,7 @@ function Set-RsDataSource
             This command will establish a connection to the Report Server located at $rsProxy using current user's credentials and update the details of data source found at '/path/to/my/datasource'.
     #>
     
-    [cmdletbinding()]
+    [CmdletBinding(SupportsShouldProcess = $true, ConfirmImpact = 'Medium')]
     param
     (
         [Alias('DataSourcePath','ItemPath', 'Path')]
@@ -74,8 +74,15 @@ function Set-RsDataSource
         [System.Management.Automation.PSCredential]
         $Credential,
         
-        $Proxy
+        $Proxy,
+
+        [switch]
+        $Force
     )
+
+    if ($Force) {
+        $ConfirmPreference = 'None'
+    }
     
     if ($PSCmdlet.ShouldProcess($RsItem, "Applying new definition"))
     {

--- a/ReportingServicesTools/Functions/CatalogItems/Set-RsDataSourcePassword.ps1
+++ b/ReportingServicesTools/Functions/CatalogItems/Set-RsDataSourcePassword.ps1
@@ -55,7 +55,10 @@ function Set-RsDataSourcePassword
         [System.Management.Automation.PSCredential]
         $Credential,
         
-        $Proxy
+        $Proxy,
+
+        [switch]
+        $Force
     )
     
     Begin
@@ -65,6 +68,10 @@ function Set-RsDataSourcePassword
     
     Process
     {
+        if ($Force) {
+            $ConfirmPreference = 'None'
+        }
+        
         foreach ($item in $Path)
         {
             if ($PSCmdlet.ShouldProcess($item, "Overwrite the password"))

--- a/ReportingServicesTools/Functions/CatalogItems/Write-RsCatalogItem.ps1
+++ b/ReportingServicesTools/Functions/CatalogItems/Write-RsCatalogItem.ps1
@@ -81,7 +81,10 @@ function Write-RsCatalogItem
         [System.Management.Automation.PSCredential]
         $Credential,
 
-        $Proxy
+        $Proxy,
+
+        [switch]
+        $Force
     )
 
     Begin
@@ -93,6 +96,10 @@ function Write-RsCatalogItem
 
     Process
     {
+        if ($Force) {
+            $ConfirmPreference = 'None'
+        }
+
         foreach ($item in $Path)
         {
             #region Manage Paths

--- a/ReportingServicesTools/Functions/CatalogItems/Write-RsFolderContent.ps1
+++ b/ReportingServicesTools/Functions/CatalogItems/Write-RsFolderContent.ps1
@@ -69,8 +69,15 @@ function Write-RsFolderContent
         [System.Management.Automation.PSCredential]
         $Credential,
 
-        $Proxy
+        $Proxy,
+
+        [switch]
+        $Force
     )
+
+    if ($Force) {
+        $ConfirmPreference = 'None'
+    }
 
     if ($PSCmdlet.ShouldProcess($Path, "Upload all contents in folder $(if ($Recurse) { "and subfolders " })to $RsFolder"))
     {

--- a/ReportingServicesTools/Functions/Security/Grant-RsCatalogItemRole.ps1
+++ b/ReportingServicesTools/Functions/Security/Grant-RsCatalogItemRole.ps1
@@ -89,8 +89,15 @@ function Grant-RsCatalogItemRole
         [System.Management.Automation.PSCredential]
         $Credential,
 
-        $Proxy
+        $Proxy,
+
+        [switch]
+        $Force
     )
+
+    if ($Force) {
+        $ConfirmPreference = 'None'
+    }
 
     if ($PSCmdlet.ShouldProcess((Get-ShouldProcessTargetweb -BoundParameters $PSBoundParameters), "Grant $RoleName on $Path to $Identity"))
     {

--- a/ReportingServicesTools/Functions/Security/Grant-RsSystemRole.ps1
+++ b/ReportingServicesTools/Functions/Security/Grant-RsSystemRole.ps1
@@ -75,8 +75,15 @@ function Grant-RsSystemRole
         [System.Management.Automation.PSCredential]
         $Credential,
         
-        $Proxy
+        $Proxy,
+
+        [switch]
+        $Force
     )
+
+    if ($Force) {
+        $ConfirmPreference = 'None'
+    }
     
     if ($PSCmdlet.ShouldProcess((Get-ShouldProcessTargetweb -BoundParameters $PSBoundParameters), "Grant $RoleName on Report Server to $Identity"))
     {

--- a/ReportingServicesTools/Functions/Security/Revoke-RsCatalogItemAccess.ps1
+++ b/ReportingServicesTools/Functions/Security/Revoke-RsCatalogItemAccess.ps1
@@ -74,8 +74,15 @@ function Revoke-RsCatalogItemAccess
         [System.Management.Automation.PSCredential]
         $Credential,
         
-        $Proxy
+        $Proxy,
+
+        [switch]
+        $Force
     )
+
+    if ($Force) {
+        $ConfirmPreference = 'None'
+    }
     
     if ($PSCmdlet.ShouldProcess((Get-ShouldProcessTargetweb -BoundParameters $PSBoundParameters), "Revoke all roles on $Path for $Identity"))
     {

--- a/ReportingServicesTools/Functions/Security/Revoke-RsSystemAccess.ps1
+++ b/ReportingServicesTools/Functions/Security/Revoke-RsSystemAccess.ps1
@@ -66,8 +66,15 @@ function Revoke-RsSystemAccess
         [System.Management.Automation.PSCredential]
         $Credential,
         
-        $Proxy
+        $Proxy,
+
+        [switch]
+        $Force
     )
+
+    if ($Force) {
+        $ConfirmPreference = 'None'
+    }
     
     if ($PSCmdlet.ShouldProcess((Get-ShouldProcessTargetweb -BoundParameters $PSBoundParameters), "Revoke all system access for $Identity"))
     {

--- a/Tests/Admin/Set-RsDatabase.Tests.ps1
+++ b/Tests/Admin/Set-RsDatabase.Tests.ps1
@@ -27,9 +27,9 @@ Describe "Set-RsDatabase" {
         $databaseName = 'ReportServer' + [System.DateTime]::Now.Ticks
         $credentialType = 'ServiceAccount'
 
-        It 'Should throw MethodInvocationException when asking for confirm' {
+        It 'Should throw exception when asking for confirm in noninteractive mode' {
             { Set-RsDatabase -DatabaseServerName $databaseServerName -DatabaseName $databaseName -DatabaseCredentialType $credentialType -Confirm -Verbose -ReportServerInstance PBIRS -ReportServerVersion SQLServervNext } |
-                Should -Throw "Read and Prompt functionality is not available"
+                Should -Throw
         }
         Set-RsDatabase -DatabaseServerName $databaseServerName -DatabaseName $databaseName -DatabaseCredentialType $credentialType -Force -Verbose -ReportServerInstance PBIRS -ReportServerVersion SQLServervNext
         
@@ -44,9 +44,9 @@ Describe "Set-RsDatabase" {
         $databaseName = 'ReportServer' + [System.DateTime]::Now.Ticks
         $credentialType = 'SQL'
         $credential = Get-SaCredentials
-        It 'Should throw MethodInvocationException when asking for confirm' {
+        It 'Should throw exception when asking for confirm in noninteractive mode' {
             { Set-RsDatabase -DatabaseServerName $databaseServerName -DatabaseName $databaseName -DatabaseCredentialType $credentialType -DatabaseCredential $credential -Confirm -Verbose -ReportServerInstance PBIRS -ReportServerVersion SQLServervNext } |
-                Should -Throw "Read and Prompt functionality is not available"
+                Should -Throw
         }
         Set-RsDatabase -DatabaseServerName $databaseServerName -DatabaseName $databaseName -DatabaseCredentialType $credentialType -DatabaseCredential $credential -Force -Verbose -ReportServerInstance PBIRS -ReportServerVersion SQLServervNext
         
@@ -61,9 +61,9 @@ Describe "Set-RsDatabase" {
         $databaseName = 'ReportServer'
         $credentialType = 'SQL'
         $credential = Get-SaCredentials
-        It 'Should throw MethodInvocationException when asking for confirm' {
+        It 'Should throw exception when asking for confirm in noninteractive mode' {
             { Set-RsDatabase -DatabaseServerName $databaseServerName -DatabaseName $databaseName -DatabaseCredentialType $credentialType -DatabaseCredential $credential -IsExistingDatabase -Confirm -Verbose -ReportServerInstance PBIRS -ReportServerVersion SQLServervNext } |
-                Should -Throw "Read and Prompt functionality is not available"
+                Should -Throw
         }
         Set-RsDatabase -DatabaseServerName $databaseServerName -DatabaseName $databaseName -DatabaseCredentialType $credentialType -DatabaseCredential $credential -IsExistingDatabase -Force -Verbose -ReportServerInstance PBIRS -ReportServerVersion SQLServervNext
         
@@ -77,9 +77,9 @@ Describe "Set-RsDatabase" {
         $databaseServerName = 'localhost'
         $databaseName = 'ReportServer'
         $credentialType = 'ServiceAccount'
-        It 'Should throw MethodInvocationException when asking for confirm' {
+        It 'Should throw exception when asking for confirm in noninteractive mode' {
             { Set-RsDatabase -DatabaseServerName $databaseServerName -DatabaseName $databaseName -DatabaseCredentialType $credentialType -IsExistingDatabase -Confirm -Verbose -ReportServerInstance PBIRS -ReportServerVersion SQLServervNext } |
-                Should -Throw "Read and Prompt functionality is not available"
+                Should -Throw
         }
         Set-RsDatabase -DatabaseServerName $databaseServerName -DatabaseName $databaseName -DatabaseCredentialType $credentialType -IsExistingDatabase -Force -Verbose -ReportServerInstance PBIRS -ReportServerVersion SQLServervNext
         

--- a/Tests/Admin/Set-RsDatabase.Tests.ps1
+++ b/Tests/Admin/Set-RsDatabase.Tests.ps1
@@ -26,7 +26,12 @@ Describe "Set-RsDatabase" {
         $databaseServerName = 'localhost'
         $databaseName = 'ReportServer' + [System.DateTime]::Now.Ticks
         $credentialType = 'ServiceAccount'
-        Set-RsDatabase -DatabaseServerName $databaseServerName -DatabaseName $databaseName -DatabaseCredentialType $credentialType -Confirm:$false -Verbose -ReportServerInstance PBIRS -ReportServerVersion SQLServervNext
+
+        It 'Should throw MethodInvocationException when asking for confirm' {
+            { Set-RsDatabase -DatabaseServerName $databaseServerName -DatabaseName $databaseName -DatabaseCredentialType $credentialType -Confirm -Verbose -ReportServerInstance PBIRS -ReportServerVersion SQLServervNext } |
+                Should -Throw -ExceptionType ([MethodInvocationException])
+        }
+        Set-RsDatabase -DatabaseServerName $databaseServerName -DatabaseName $databaseName -DatabaseCredentialType $credentialType -Force -Verbose -ReportServerInstance PBIRS -ReportServerVersion SQLServervNext
         
         It "Should update database and credentials" {
             Get-DatabaseName | Should be $databaseName

--- a/Tests/Admin/Set-RsDatabase.Tests.ps1
+++ b/Tests/Admin/Set-RsDatabase.Tests.ps1
@@ -29,7 +29,7 @@ Describe "Set-RsDatabase" {
 
         It 'Should throw MethodInvocationException when asking for confirm' {
             { Set-RsDatabase -DatabaseServerName $databaseServerName -DatabaseName $databaseName -DatabaseCredentialType $credentialType -Confirm -Verbose -ReportServerInstance PBIRS -ReportServerVersion SQLServervNext } |
-                Should -Throw -ExceptionType ([MethodInvocationException])
+                Should -Throw "Read and Prompt functionality is not available"
         }
         Set-RsDatabase -DatabaseServerName $databaseServerName -DatabaseName $databaseName -DatabaseCredentialType $credentialType -Force -Verbose -ReportServerInstance PBIRS -ReportServerVersion SQLServervNext
         
@@ -44,7 +44,11 @@ Describe "Set-RsDatabase" {
         $databaseName = 'ReportServer' + [System.DateTime]::Now.Ticks
         $credentialType = 'SQL'
         $credential = Get-SaCredentials
-        Set-RsDatabase -DatabaseServerName $databaseServerName -DatabaseName $databaseName -DatabaseCredentialType $credentialType -DatabaseCredential $credential -Confirm:$false -Verbose -ReportServerInstance PBIRS -ReportServerVersion SQLServervNext
+        It 'Should throw MethodInvocationException when asking for confirm' {
+            { Set-RsDatabase -DatabaseServerName $databaseServerName -DatabaseName $databaseName -DatabaseCredentialType $credentialType -DatabaseCredential $credential -Confirm -Verbose -ReportServerInstance PBIRS -ReportServerVersion SQLServervNext } |
+                Should -Throw "Read and Prompt functionality is not available"
+        }
+        Set-RsDatabase -DatabaseServerName $databaseServerName -DatabaseName $databaseName -DatabaseCredentialType $credentialType -DatabaseCredential $credential -Force -Verbose -ReportServerInstance PBIRS -ReportServerVersion SQLServervNext
         
         It "Should update database and credentials" {
             Get-DatabaseName | Should be $databaseName
@@ -57,7 +61,11 @@ Describe "Set-RsDatabase" {
         $databaseName = 'ReportServer'
         $credentialType = 'SQL'
         $credential = Get-SaCredentials
-        Set-RsDatabase -DatabaseServerName $databaseServerName -DatabaseName $databaseName -DatabaseCredentialType $credentialType -DatabaseCredential $credential -IsExistingDatabase -Confirm:$false -Verbose -ReportServerInstance PBIRS -ReportServerVersion SQLServervNext
+        It 'Should throw MethodInvocationException when asking for confirm' {
+            { Set-RsDatabase -DatabaseServerName $databaseServerName -DatabaseName $databaseName -DatabaseCredentialType $credentialType -DatabaseCredential $credential -IsExistingDatabase -Confirm -Verbose -ReportServerInstance PBIRS -ReportServerVersion SQLServervNext } |
+                Should -Throw "Read and Prompt functionality is not available"
+        }
+        Set-RsDatabase -DatabaseServerName $databaseServerName -DatabaseName $databaseName -DatabaseCredentialType $credentialType -DatabaseCredential $credential -IsExistingDatabase -Force -Verbose -ReportServerInstance PBIRS -ReportServerVersion SQLServervNext
         
         It "Should update database and credentials" {
             Get-DatabaseName | Should be $databaseName
@@ -69,7 +77,11 @@ Describe "Set-RsDatabase" {
         $databaseServerName = 'localhost'
         $databaseName = 'ReportServer'
         $credentialType = 'ServiceAccount'
-        Set-RsDatabase -DatabaseServerName $databaseServerName -DatabaseName $databaseName -DatabaseCredentialType $credentialType -IsExistingDatabase -Confirm:$false -Verbose -ReportServerInstance PBIRS -ReportServerVersion SQLServervNext
+        It 'Should throw MethodInvocationException when asking for confirm' {
+            { Set-RsDatabase -DatabaseServerName $databaseServerName -DatabaseName $databaseName -DatabaseCredentialType $credentialType -IsExistingDatabase -Confirm -Verbose -ReportServerInstance PBIRS -ReportServerVersion SQLServervNext } |
+                Should -Throw "Read and Prompt functionality is not available"
+        }
+        Set-RsDatabase -DatabaseServerName $databaseServerName -DatabaseName $databaseName -DatabaseCredentialType $credentialType -IsExistingDatabase -Force -Verbose -ReportServerInstance PBIRS -ReportServerVersion SQLServervNext
         
         It "Should update database and credentials" {
             Get-DatabaseName | Should be $databaseName


### PR DESCRIPTION
Fixes #333

Changes proposed in this pull request:
 - Implements `-Force`

How to test this code:
 - Use `-Force` instead of `-Confirm:$false` on any cmdlet that requires confirmation

Has been tested on (remove any that don't apply):
 - Powershell 5.1
 - Windows 10
 - SQL Server 2012
