### PR TITLE
Fixed missing param on New-RsRestCacheRefreshPlan

### DIFF
--- a/ReportingServicesTools/Functions/CatalogItems/Rest/New-RsRestCacheRefreshPlan.ps1
+++ b/ReportingServicesTools/Functions/CatalogItems/Rest/New-RsRestCacheRefreshPlan.ps1
@@ -27,6 +27,9 @@ function New-RsRestCacheRefreshPlan
 
         .PARAMETER WebSession
             Specify the session to be used when making calls to REST Endpoint.
+            
+        .PARAMETER Description
+            Specify the description to be added to the CacheRefreshPlan.
 
         .EXAMPLE
             New-RsRestCacheRefreshPlan -RsItem /ReportCatalog
@@ -124,7 +127,7 @@ function New-RsRestCacheRefreshPlan
                             "Recurrence" = $recurrence;
                         }
                     }
-                    "ScheduleDescription" = $Description;
+                    "Description" = $Description;
                 }
 
                 $payloadJson = ConvertTo-Json $payload -Depth 15


### PR DESCRIPTION
Fixes #337  .

Changes proposed in this pull request:
- Add Description parameter and update param binding

How to test this code:
`New-RsRestCacheRefreshPlan -RsItem $rsItemName -ReportPortalUri $reportPortalUri -Description "temp" -WebSession $session -RestApiVersion $ApiVersion`

Has not been tested.
