### PR TITLE
Update ModuleVersion in manifest

### DIFF
--- a/ReportingServicesTools/ReportingServicesTools.psd1
+++ b/ReportingServicesTools/ReportingServicesTools.psd1
@@ -7,7 +7,7 @@
     RootModule = 'ReportingServicesTools.psm1'
     
     # Version number of this module.
-    ModuleVersion = '0.0.6.0'
+    ModuleVersion = '0.0.6.6'
     
     # ID used to uniquely identify this module
     GUID = '9d139310-ce45-41ce-8e8b-d76335aa1789'


### PR DESCRIPTION
Fixes #[343](https://github.com/microsoft/ReportingServicesTools/issues/343) .

Changes proposed in this pull request:
 - Update ModuleVersion in ReportingServicesTools.psd1
 
How to test this code:

1. Uninstall the current version of ReportingServicesTools
2. Install via one of the two Invoke-Expression installation methods
`Invoke-Expression (Invoke-WebRequest https://raw.githubusercontent.com/Microsoft/ReportingServicesTools/master/Install.ps1)`
or
`Invoke-Expression (Invoke-WebRequest https://aka.ms/rstools)`
3. Note as part of the installation, the installed commands are returned and show version 0.0.6.6

Has been tested on (remove any that don't apply):
 - Powershell versions 5.1.19041.1023 and 7.1.4
 - Windows 10

