### PR TITLE
#351 fixed New-RsRestCacheRefreshPlan for custom credentials

### DIFF
--- a/ReportingServicesTools/Functions/CatalogItems/Rest/New-RsRestCacheRefreshPlan.ps1
+++ b/ReportingServicesTools/Functions/CatalogItems/Rest/New-RsRestCacheRefreshPlan.ps1
@@ -133,7 +133,14 @@ function New-RsRestCacheRefreshPlan
                 $payloadJson = ConvertTo-Json $payload -Depth 15
                 Write-Verbose "Payload: $payloadJson"
 
-                $response = Invoke-RestMethod -Uri $refreshplansUri -Method Post -WebSession $WebSession -Body ([System.Text.Encoding]::UTF8.GetBytes($payloadJson)) -ContentType "application/json" -UseDefaultCredentials -Verbose:$false
+                if ($Credential -ne $null)
+                {
+                    $response = Invoke-WebRequest -Uri $refreshplansUri -Method Post -WebSession $WebSession -Body ([System.Text.Encoding]::UTF8.GetBytes($payloadJson)) -ContentType "application/json" -Credential $Credential -Verbose:$false
+                }
+                else
+                {
+                    $response = Invoke-WebRequest -Uri $refreshplansUri -Method Post -WebSession $WebSession -Body ([System.Text.Encoding]::UTF8.GetBytes($payloadJson)) -ContentType "application/json" -UseDefaultCredentials -Verbose:$false
+                }
 
                 Write-Verbose "Schedule payload for $RsItem was created successfully!"
                 return $response


### PR DESCRIPTION
Fixes # 351

Changes proposed in this pull request:
conditional switch for credentials parameter based on user provided custom credentials

How to test this code:
run New-RsRestCacheRefreshPlan  with custom credential parameter, and without it.
if default logged in user doesn't have access, it shouldn't be able to create new cache refresh plan, but custom credentials user should be able to create it.

Has been tested on (remove any that don't apply):
 - Powershell 5 and above
 - Windows 7 and above
 - SQL Server 2012 and above
