### PR TITLE
Document import issue

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,6 +151,11 @@ To execute the tests run (this will execute the CatalogItems test only which doe
 .\Test.ps1
 ```
 
+## Import Known Issue
+Workaround for newer versions of PowerShell (version 7.0+)
+```powershell
+Import-Module ReportingServicesTools -UseWindowsPowerShell
+```
 ## Style Guidelines
 
 If you have any scripts you would like to share, we request you to please format your scripts according to the guidelines created by the team behind the DSC Resource Kit. (https://github.com/PowerShell/DscResources/blob/master/StyleGuidelines.md) and the PowerShell verbs https://msdn.microsoft.com/en-us/library/ms714428(v=vs.85).aspx


### PR DESCRIPTION
Document known issue with Import-Module for newer versions of PowerShell

See workaround documented by LarnuUK in ISSUE-239

Fixes #239.

Changes proposed in this pull request:
 - Document workaround using with PowerShell 7.0+

How to test this code:
 - Documentation only
 - Install ReportingServicesTools on PowerShell 7.0 or higher
 - Import-Module ReportingServicesTools -UseWindowsPowerShell
 - Use ReportingServicesTools without getting errors about New-WebServiceProxy or switching to an older version of PowerShell.

Has been tested on (remove any that don't apply):
 - Powershell 7 and above
 - Windows 10 and above
 - SQL Server 2012 and above
