### PR TITLE
Feature/bug fix for Set-RsSubscription to check for $subproperties -ne $null

### DIFF
--- a/ReportingServicesTools/Functions/CatalogItems/Set-RsSubscription.ps1
+++ b/ReportingServicesTools/Functions/CatalogItems/Set-RsSubscription.ps1
@@ -32,8 +32,10 @@ function Set-RsSubscription
             Used to change the EndDate of subscription. 
 
         .PARAMETER Owner
-            Used to change the owner of a subscription. 
+            Used to change the owner of a subscription.
             
+        .PARAMETER SubProperties
+            Subscription object returned from Get-RsSubscription
           
         .EXAMPLE
             Get-RsSubscription -path '/Finance/ImportantReports' | Set-RsSubscription -EndDate 9/9/2099
@@ -129,7 +131,7 @@ try
     if ($StartDateTime -ne $null -or $EndDate -ne $null -or $SubProperties -ne $null)
     {
       $null = $Proxy.SetSubscriptionProperties($SubProperties.subscriptionID, $SubProperties.DeliverySettings, $SubProperties.Description, $SubProperties.EventType, $XMLMatch.OuterXml, $SubProperties.Values) 
-      Write-Verbose "subscription $($SubProperties.subscriptionId) for $($SubProperties.report) report successfully updated!"
+      Write-Verbose "Subscription $($SubProperties.subscriptionId) for $($SubProperties.report) report successfully updated!"
     }
     }
     Catch

--- a/ReportingServicesTools/Functions/CatalogItems/Set-RsSubscription.ps1
+++ b/ReportingServicesTools/Functions/CatalogItems/Set-RsSubscription.ps1
@@ -126,7 +126,7 @@ try
         
     }
     
-    if ($StartDateTime -ne $null -or $EndDate -ne $null)
+    if ($StartDateTime -ne $null -or $EndDate -ne $null -or $SubProperties -ne $null)
     {
       $null = $Proxy.SetSubscriptionProperties($SubProperties.subscriptionID, $SubProperties.DeliverySettings, $SubProperties.Description, $SubProperties.EventType, $XMLMatch.OuterXml, $SubProperties.Values) 
       Write-Verbose "subscription $($SubProperties.subscriptionId) for $($SubProperties.report) report successfully updated!"


### PR DESCRIPTION
Fixes #356 

Changes proposed in this pull request:
 - Execute $proxy.SetSubscriptionProperties if $subproperties not null
 - Added context help for $subproperties parameter

How to test this code:
 - Get-RsSubscription | Set-RsSubscription 
 - 
 - 

Has been tested on (remove any that don't apply):
 - ReportingService2010 soap endpoint
