### PR TITLE
Support for creating hidden datasources using New-RsDataSource, and assertions for Write-RsCatalogItem that items are created as hidden when specified

### DIFF
--- a/ReportingServicesTools/Functions/CatalogItems/New-RsDataSource.ps1
+++ b/ReportingServicesTools/Functions/CatalogItems/New-RsDataSource.ps1
@@ -6,101 +6,104 @@ function New-RsDataSource
     <#
         .SYNOPSIS
             This script creates a new data source on Report Server.
-        
+
         .DESCRIPTION
             This script creates a new data source on Report Server.
-        
+
         .PARAMETER RsFolder
             Specify the location where the data source should be created at.
-        
+
         .PARAMETER Name
             Specify the name of the the new data source
 
         .PARAMETER Description
             Specify the description to be added to the data source.
-        
+
         .PARAMETER Extension
             Specify the extension of the new data source (e.g. SQL, SQLAZURE, OLEDB, OLEDB-MD, etc.) For full list, please look at <Extensions>\<Data> node in C:\Program Files\Microsoft SQL Server\MSRS{VersionNumber}.{InstanceName}\Reporting Services\ReportServer\RSReportServer.config.
-        
+
         .PARAMETER ConnectionString
             Specify the connection string for the new data source.
-        
+
         .PARAMETER CredentialRetrieval
             Specify the type of authentication to use: None, Prompt, Integrated, Store. Please view https://msdn.microsoft.com/en-us/library/reportservice2010.datasourcedefinition.credentialretrieval.aspx for more details on each option.
-        
+
         .PARAMETER DatasourceCredentials
             Specify the Credentials to use when connecting to the data source.
-        
+
         .PARAMETER Prompt
             Specify the prompt to display to user.
-        
+
         .PARAMETER ImpersonateUser
             Specify whether to impersonate using the credentials specify when connecting to the data source. You must specify DatasourceCredentials if you specify this switch.
-        
+
         .PARAMETER WindowsCredentials
             Specify whether the credentials specified are Windows credentials or not. You must specify DatasourceCredentials if you specify this switch.
-        
+
         .PARAMETER Disabled
             Creates this data source in a disabled state.
-        
+
         .PARAMETER Overwrite
             Overwrite the old entry, if an existing data source with same name exists at the specified Path.
-        
+
+        .PARAMETER Hidden
+            Mark the item as hidden on the destination server.
+
         .PARAMETER ReportServerUri
             Specify the Report Server URL to your SQL Server Reporting Services Instance.
             Use the "Connect-RsReportServer" function to set/update a default value.
-        
+
         .PARAMETER Credential
             Specify the credentials to use when connecting to the Report Server.
             Use the "Connect-RsReportServer" function to set/update a default value.
-        
+
         .PARAMETER Proxy
             Report server proxy to use.
             Use "New-RsWebServiceProxy" to generate a proxy object for reuse.
             Useful when repeatedly having to connect to multiple different Report Server.
-        
+
         .EXAMPLE
             New-RsDataSource -RsFolder '/' -Name 'My Data Source' -Extension 'SQL' -ConnectionString 'Data Source=.;Initial Catalog=MyDb;' -CredentialRetrieval 'None'
             Description
             -----------
             This command will establish a connection to the Report Server located at http://localhost/reportserver using current user's credentials and create a new SQL Server data source called 'My Data Source' at the root folder. When connecting to this data source, it will use not specify any credentials.
-        
+
         .EXAMPLE
             New-RsDataSource -RsFolder '/' -Name 'My Data Source' -Extension 'SQL' -ConnectionString 'Data Source=.;Initial Catalog=MyDb;' -CredentialRetrieval 'Integrated'
             Description
             -----------
             This command will establish a connection to the Report Server located at http://localhost/reportserver using current user's credentials and create a new SQL Server data source called 'My Data Source' at the root folder. When connecting to this data source, it will assume current user's identity.
-        
+
         .EXAMPLE
             New-RsDataSource -RsFolder '/' -Name 'My Data Source' -Extension 'SQL' -ConnectionString 'Data Source=.;Initial Catalog=MyDb;' -CredentialRetrieval 'Prompt' -Prompt 'Please enter your username and password'
             Description
             -----------
             This command will establish a connection to the Report Server located at http://localhost/reportserver using current user's credentials and create a new SQL Server data source called 'My Data Source' at the root folder. When connecting to this data source, it will prompt user for Database credentials.
-        
+
         .EXAMPLE
             New-RsDataSource -RsFolder '/' -Name 'My Data Source' -Extension 'SQL' -ConnectionString 'Data Source=.;Initial Catalog=MyDb;' -CredentialRetrieval 'Prompt' -Prompt 'Please enter your username and password' -WindowsCredentials
             Description
             -----------
             This command will establish a connection to the Report Server located at http://localhost/reportserver using current user's credentials and create a new SQL Server data source called 'My Data Source' at the root folder. When connecting to this data source, it will prompt user for Windows credentials.
-        
+
         .EXAMPLE
             New-RsDataSource -RsFolder '/' -Name 'My Data Source' -Extension 'SQL' -ConnectionString 'Data Source=.;Initial Catalog=MyDb;' -CredentialRetrieval 'Store' -DatasourceCredentials 'sa' -ImpersonateUser
             Description
             -----------
             This command will establish a connection to the Report Server located at http://localhost/reportserver using current user's credentials and create a new SQL Server data source called 'My Data Source' at the root folder. When connecting to this data source, the specified credentials will be treated as Database credentials.
-        
+
         .EXAMPLE
             New-RsDataSource -RsFolder '/' -Name 'My Data Source' -Extension 'SQL' -ConnectionString 'Data Source=.;Initial Catalog=MyDb;' -CredentialRetrieval 'Store' -DatasourceCredentials 'sa' -ImpersonateUser -WindowsCredentials
             Description
             -----------
             This command will establish a connection to the Report Server located at http://localhost/reportserver using current user's credentials and create a new SQL Server data source called 'My Data Source' at the root folder. When connecting to this data source, the specified credentials will be treated as Windows credentials.
-        
+
         .EXAMPLE
             New-RsDataSource -RsFolder '/' -Name 'My Data Source' -Extension 'SQL' -ConnectionString 'Data Source=.;Initial Catalog=MyDb;' -CredentialRetrieval 'None' -Overwrite
             Description
             -----------
             This command will establish a connection to the Report Server located at http://localhost/reportserver using current user's credentials and create a new SQL Server data source called 'My Data Source' at the root folder. If data source already exists, it will be overwriten.
-            
+
     #>
 
     [cmdletbinding()]
@@ -110,21 +113,21 @@ function New-RsDataSource
         [Parameter(Mandatory = $True)]
         [string]
         $RsFolder,
-        
+
         [Parameter(Mandatory = $True)]
         [string]
         $Name,
 
         [string]
         $Description,
-        
+
         [Parameter(Mandatory = $True)]
         [string]
         $Extension,
 
         [string]
         $ConnectionString,
-        
+
         [Parameter(Mandatory = $True)]
         [ValidateSet("None", "Prompt", "Integrated", "Store")]
         [string]
@@ -147,17 +150,20 @@ function New-RsDataSource
 
         [Switch]
         $Overwrite,
-        
+
+        [switch]
+        $Hidden,
+
         [string]
         $ReportServerUri,
-        
+
         [Alias('ReportServerCredentials')]
         [System.Management.Automation.PSCredential]
         $Credential,
-        
+
         $Proxy
     )
-    
+
     $Proxy = New-RsWebServiceProxyHelper -BoundParameters $PSBoundParameters
 
     if (($CredentialRetrieval -eq 'STORE') -and ($DatasourceCredentials.UserName -eq $null))
@@ -179,11 +185,11 @@ function New-RsDataSource
 
     $datasource = New-Object $datasourceDataType
     $datasource.ConnectString = $ConnectionString
-    $datasource.Enabled = $true    
+    $datasource.Enabled = $true
     $datasource.Extension = $Extension
     $datasource.WindowsCredentials = $WindowsCredentials
     $datasource.Prompt = $Prompt
-    
+
     if ($Disabled)
     {
         $datasource.Enabled = $false
@@ -212,6 +218,14 @@ function New-RsDataSource
         $descriptionProperty.Name = 'Description'
         $descriptionProperty.Value = $Description
         $additionalProperties.Add($descriptionProperty)
+    }
+
+    if ($Hidden)
+    {
+        $hiddenProperty = New-Object $propertyDataType
+        $hiddenProperty.Name = 'Hidden'
+        $hiddenProperty.Value = $Hidden
+        $additionalProperties.Add($hiddenProperty)
     }
 
     try

--- a/ReportingServicesTools/Functions/CatalogItems/Write-RsCatalogItem.ps1
+++ b/ReportingServicesTools/Functions/CatalogItems/Write-RsCatalogItem.ps1
@@ -159,7 +159,7 @@ function Write-RsCatalogItem
                         {
                             throw "Data Source Definition not found in the specified file: $EntirePath!"
                         }
-    
+
                         $NewRsDataSourceParam = @{
                             Proxy = $Proxy
                             RsFolder = $RsFolder
@@ -169,11 +169,12 @@ function Write-RsCatalogItem
                             Disabled = ("false" -like $content.DataSourceDefinition.Enabled)
                             CredentialRetrieval = 'None'
                             Overwrite = $Overwrite
+                            Hidden = $Hidden
                         }
                     }
                     elseif ($item.Extension -eq '.rds')
                     {
-                        if ($content -eq $null -or 
+                        if ($content -eq $null -or
                             $content.RptDataSource -eq $null -or
                             $content.RptDataSource.Name -eq $null -or
                             $content.RptDataSource.ConnectionProperties -eq $null -or
@@ -203,6 +204,7 @@ function Write-RsCatalogItem
                             Disabled = $false
                             CredentialRetrieval = $credentialRetrieval
                             Overwrite = $Overwrite
+                            Hidden = $Hidden
                         }
 
                         if ($credentialRetrieval -eq "prompt")
@@ -257,7 +259,7 @@ function Write-RsCatalogItem
                         $hiddenProperty.Value = $Hidden
                         $additionalProperties.Add($hiddenProperty)
                     }
-                
+
                     $bytes = [System.IO.File]::ReadAllBytes($EntirePath)
                     $warnings = $null
                     try

--- a/Tests/CatalogItems/New-RsDataSource.Tests.ps1
+++ b/Tests/CatalogItems/New-RsDataSource.Tests.ps1
@@ -21,7 +21,7 @@ Function Get-ExistingDataExtension
 }
 
 Describe "New-RsDataSource" {
-    Context "Create RsDataSource with minimal parameters"{
+    Context "Create RsDataSource with minimal parameters" {
         # Declare datasource Name, Extension, CredentialRetrieval, and DataSource path.
         $dataSourceName = 'SutDataSourceMinParameters' + [guid]::NewGuid()
         $extension = Get-ExistingDataExtension
@@ -39,7 +39,7 @@ Describe "New-RsDataSource" {
         Remove-RsCatalogItem -RsFolder $dataSourcePath -Confirm:$false
     }
 
-    Context "Create RsDataSource with ReportServerUri parameter"{
+    Context "Create RsDataSource with ReportServerUri parameter" {
         # Declare datasource Name, Extension, CredentialRetrieval, ReportServerUri and DataSource path.
         $dataSourceName = 'SutDataSourceReportServerUriParameter' + [guid]::NewGuid()
         $extension = Get-ExistingDataExtension
@@ -54,7 +54,7 @@ Describe "New-RsDataSource" {
         Remove-RsCatalogItem -RsFolder $dataSourcePath -Confirm:$false
     }
 
-	Context "Create RsDataSource with Hidden parameter"{
+	Context "Create RsDataSource with Hidden parameter" {
         # Declare datasource Name, Extension, CredentialRetrieval, ReportServerUri and DataSource path.
         $dataSourceName = 'SutDataSourceReportServerUriParameter' + [guid]::NewGuid()
         $extension = Get-ExistingDataExtension
@@ -65,14 +65,23 @@ Describe "New-RsDataSource" {
         It "Should be a new data source" {
             {Get-RsDataSource -Path $dataSourcePath } | Should not throw
         }
-		It "Should be hidden" {
-            (Get-RsDataSource -Path $dataSourcePath).Hidden | Should -BeTrue
-		}
+
+        It "Should be hidden" {
+            #Hidden property is not returned for a datasource.
+            #(Get-RsDataSource -Path $dataSourcePath).Hidden | Should -BeTrue
+
+            #Get the datasource as folder content
+            $item=Get-RsFolderContent -RsFolder '/' | Where-Object -Property Name -eq -Value $dataSourceName
+            $item.Name | Should -Be $dataSourceName
+            $item.Hidden | Should -BeTrue
+        }
+
+
         # Removing folders used for testing
         Remove-RsCatalogItem -RsFolder $dataSourcePath -Confirm:$false
     }
 
-    Context "Create RsDataSource with Proxy parameter"{
+    Context "Create RsDataSource with Proxy parameter" {
         # Declare datasource Name, Extension, CredentialRetrieval, Proxy and DataSource path.
         $dataSourceName = 'SutDataSourceProxyParameter' + [guid]::NewGuid()
         $extension = Get-ExistingDataExtension
@@ -87,7 +96,7 @@ Describe "New-RsDataSource" {
         Remove-RsCatalogItem -RsFolder $dataSourcePath -Confirm:$false
     }
 
-    Context "Create RsDataSource with connection string parameter"{
+    Context "Create RsDataSource with connection string parameter" {
         # Declare datasource Name, Extension, CredentialRetrieval, Connection String and DataSource path.
         $dataSourceName = 'SutDataSourceConnectionStringParameter' + [guid]::NewGuid()
         $extension = Get-ExistingDataExtension
@@ -106,7 +115,7 @@ Describe "New-RsDataSource" {
         Remove-RsCatalogItem -RsFolder $dataSourcePath -Confirm:$false
     }
 
-    Context "Create RsDataSource with Proxy and ReportServerUri parameters"{
+    Context "Create RsDataSource with Proxy and ReportServerUri parameters" {
         # Declare datasource Name, Extension, CredentialRetrieval, and DataSource path.
         $dataSourceName = 'SutDataSourceProxyAndReportServerUriParameters' + [guid]::NewGuid()
         $extension = Get-ExistingDataExtension
@@ -122,7 +131,7 @@ Describe "New-RsDataSource" {
         Remove-RsCatalogItem -RsFolder $dataSourcePath -Confirm:$false
     }
 
-     Context "Create RsDataSource with unsupported RsDataSource Extension validation"{
+     Context "Create RsDataSource with unsupported RsDataSource Extension validation" {
         # Declare datasource Name, Extension, CredentialRetrieval, and DataSource path.
         $dataSourceName = 'SutDataSurceExtensionException' + [guid]::NewGuid()
         $extension = 'InvalidExtension'
@@ -185,7 +194,7 @@ Describe "New-RsDataSource" {
     #      Remove-RsCatalogItem -RsFolder $dataSourcePath -Confirm:$false
     #  }
 
-    Context "Create RsDataSource with Windows Credentials Parameter"{
+    Context "Create RsDataSource with Windows Credentials Parameter" {
         # Declare datasource Name, Extension, CredentialRetrieval, and DataSource path.
         $dataSourceName = 'SutDataSurceWindowsCredentials' + [guid]::NewGuid()
         $extension = Get-ExistingDataExtension
@@ -206,7 +215,7 @@ Describe "New-RsDataSource" {
         Remove-RsCatalogItem -RsFolder $dataSourcePath -Confirm:$false
     }
 
-    Context "Create RsDataSource with Prompt Credentials Retrieval"{
+    Context "Create RsDataSource with Prompt Credentials Retrieval" {
         # Declare datasource Name, Extension, CredentialRetrieval (Prompt), and DataSource path.
         $dataSourceName = 'SutDataSurcePrompt' + [guid]::NewGuid()
         $extension = Get-ExistingDataExtension
@@ -221,7 +230,7 @@ Describe "New-RsDataSource" {
         Remove-RsCatalogItem -RsFolder $dataSourcePath -Confirm:$false
     }
 
-    Context "Create RsDataSource and Overwrite it"{
+    Context "Create RsDataSource and Overwrite it" {
         # Declare datasource name, extension, credential retrieval, and data source path.
         $dataSourceName = 'SutDataSourceOverwrite' + [guid]::NewGuid()
         $extension = 'SQL'
@@ -240,7 +249,7 @@ Describe "New-RsDataSource" {
         Remove-RsCatalogItem -RsFolder $dataSourcePath -Confirm:$false
     }
 
-    Context "Create RsDataSource with description"{
+    Context "Create RsDataSource with description" {
         # Declare datasource Name, Extension, CredentialRetrieval, and DataSource path.
         $dataSourceName = 'SutDataSourceDescription' + [guid]::NewGuid()
         $extension = Get-ExistingDataExtension

--- a/Tests/CatalogItems/New-RsDataSource.Tests.ps1
+++ b/Tests/CatalogItems/New-RsDataSource.Tests.ps1
@@ -11,7 +11,7 @@ Function Create-PSCredential
         )
        $SecurePassword = ConvertTo-SecureString $Password -AsPlainText -Force
        $ps_credential = New-Object System.Management.Automation.PSCredential ($UserName, $SecurePassword)
-       Return $ps_credential 
+       Return $ps_credential
 }
 
 Function Get-ExistingDataExtension
@@ -54,12 +54,30 @@ Describe "New-RsDataSource" {
         Remove-RsCatalogItem -RsFolder $dataSourcePath -Confirm:$false
     }
 
+	Context "Create RsDataSource with Hidden parameter"{
+        # Declare datasource Name, Extension, CredentialRetrieval, ReportServerUri and DataSource path.
+        $dataSourceName = 'SutDataSourceReportServerUriParameter' + [guid]::NewGuid()
+        $extension = Get-ExistingDataExtension
+        $credentialRetrieval = 'None'
+        $reportServerUri = 'http://localhost/reportserver'
+        $dataSourcePath = '/' + $dataSourceName
+        New-RsDataSource -RsFolder '/' -Name $dataSourceName -Extension $extension -CredentialRetrieval $credentialRetrieval -ReportServerUri $reportServerUri -Hidden
+        It "Should be a new data source" {
+            {Get-RsDataSource -Path $dataSourcePath } | Should not throw
+        }
+		It "Should be hidden" {
+            (Get-RsDataSource -Path $dataSourcePath).Hidden | Should -BeTrue
+		}
+        # Removing folders used for testing
+        Remove-RsCatalogItem -RsFolder $dataSourcePath -Confirm:$false
+    }
+
     Context "Create RsDataSource with Proxy parameter"{
         # Declare datasource Name, Extension, CredentialRetrieval, Proxy and DataSource path.
         $dataSourceName = 'SutDataSourceProxyParameter' + [guid]::NewGuid()
         $extension = Get-ExistingDataExtension
         $credentialRetrieval = 'None'
-        $proxy = New-RsWebServiceProxy 
+        $proxy = New-RsWebServiceProxy
         $dataSourcePath = '/' + $dataSourceName
         New-RsDataSource -RsFolder '/' -Name $dataSourceName -Extension $extension -CredentialRetrieval $credentialRetrieval -Proxy $proxy
         It "Should be a new data source" {
@@ -93,7 +111,7 @@ Describe "New-RsDataSource" {
         $dataSourceName = 'SutDataSourceProxyAndReportServerUriParameters' + [guid]::NewGuid()
         $extension = Get-ExistingDataExtension
         $credentialRetrieval = 'None'
-        $proxy = New-RsWebServiceProxy 
+        $proxy = New-RsWebServiceProxy
         $dataSourcePath = '/' + $dataSourceName
         $reportServerUri = 'http://localhost/reportserver'
         New-RsDataSource -RsFolder '/' -Name $dataSourceName -Extension $extension -CredentialRetrieval $credentialRetrieval -Proxy $proxy -ReportServerUri $reportServerUri
@@ -111,7 +129,7 @@ Describe "New-RsDataSource" {
         $credentialRetrieval = 'Integrated'
         $dataSourcePath = '/' + $dataSourceName
         It "Should throw an exception when datasource is failed to be create" {
-             { New-RsDataSource -RsFolder '/' -Name $dataSourceName -Extension $extension -CredentialRetrieval $credentialRetrieval } | Should throw 
+             { New-RsDataSource -RsFolder '/' -Name $dataSourceName -Extension $extension -CredentialRetrieval $credentialRetrieval } | Should throw
              { Get-RsDataSource -Path $dataSourcePath } | Should throw
         }
     }
@@ -123,7 +141,7 @@ Describe "New-RsDataSource" {
         $credentialRetrieval = 'Store'
         $dataSourcePath = '/' + $dataSourceName
         It "Should throw an exception when Store credential retrieval are given without providing credential" {
-            { New-RsDataSource -RsFolder '/' -Name $dataSourceName -Extension $extension -CredentialRetrieval $credentialRetrieval } | Should throw 
+            { New-RsDataSource -RsFolder '/' -Name $dataSourceName -Extension $extension -CredentialRetrieval $credentialRetrieval } | Should throw
             { Get-RsDataSource -Path $dataSourcePath } | Should throw
         }
     }
@@ -157,7 +175,7 @@ Describe "New-RsDataSource" {
     #      $password ='MyPassword'
     #      $userName = [System.Security.Principal.WindowsIdentity]::GetCurrent().Name
     #      $dataSourceCredentials = Create-PSCredential -User $userName -Password $password
-    #      New-RsDataSource -RsFolder '/' -Name $dataSourceName -Extension $extension -CredentialRetrieval $credentialRetrieval -DatasourceCredentials $dataSourceCredentials -ImpersonateUser  
+    #      New-RsDataSource -RsFolder '/' -Name $dataSourceName -Extension $extension -CredentialRetrieval $credentialRetrieval -DatasourceCredentials $dataSourceCredentials -ImpersonateUser
     #      $dataSource = Get-RsDataSource -Path $dataSourcePath
     #      It "Should be a new data source" {
     #          $dataSource.Count | Should Be 1
@@ -215,7 +233,7 @@ Describe "New-RsDataSource" {
         New-RsDataSource -RsFolder '/' -Name $dataSourceName -Extension $extension -CredentialRetrieval $credentialRetrievalChange -Overwrite
         $dataSource = Get-RsDataSource -Path $dataSourcePath
         It "Should overwrite a datasource" {
-            $dataSource.CredentialRetrieval | Should be  $credentialRetrievalChange 
+            $dataSource.CredentialRetrieval | Should be  $credentialRetrievalChange
             $dataSource.Count | Should Be 1
         }
         # Removing folders used for testing
@@ -240,7 +258,7 @@ Describe "New-RsDataSource" {
             $descriptionProperty = $properties | Where { $_.Name -eq 'Description' }
             $descriptionProperty | Should Not BeNullOrEmpty
             $descriptionProperty.Value | Should Be $description
-            
+
         }
         # Removing folders used for testing
         Remove-RsCatalogItem -RsFolder $dataSourcePath -Confirm:$false

--- a/Tests/CatalogItems/Write-RsCatalogItem.Tests.ps1
+++ b/Tests/CatalogItems/Write-RsCatalogItem.Tests.ps1
@@ -46,6 +46,7 @@ Describe "Write-RsCatalogItem" {
             $uploadedReport = (Get-RsFolderContent -RsFolder $folderPath ) | Where-Object TypeName -eq 'Report'
             $uploadedReport.Name | Should Be 'emptyReport'
             $uploadedReport.Description | Should Be 'newDescription'
+            $uploadedReport.Hidden | Should -BeTrue
         }
 
         It "Should upload a local RsDataSource in Report Server" {
@@ -53,6 +54,7 @@ Describe "Write-RsCatalogItem" {
             Write-RsCatalogItem -Path $localDataSourcePath -RsFolder $folderPath -Hidden
             $uploadedDataSource = (Get-RsFolderContent -RsFolder $folderPath ) | Where-Object TypeName -eq 'DataSource'
             $uploadedDataSource.Name | Should Be 'SutWriteRsFolderContent_DataSource'
+            $uploadedDataSource.Hidden | Should -BeTrue
         }
 
         It "Should upload a local DataSet in Report Server" {
@@ -60,6 +62,7 @@ Describe "Write-RsCatalogItem" {
             Write-RsCatalogItem -Path $localDataSetPath -RsFolder $folderPath -Hidden
             $uploadedDataSet = (Get-RsFolderContent -RsFolder $folderPath ) | Where-Object TypeName -eq 'DataSet'
             $uploadedDataSet.Name | Should Be 'UnDataset'
+            $uploadedDataSet.Hidden | Should -BeTrue
         }
         # Removing folders used for testing
         Remove-RsCatalogItem -RsFolder $folderPath -Confirm:$false


### PR DESCRIPTION
`New-RsDataSource` is lacking a `$Hidden` switch parameter to create hidden data sources.
`Write-RsCatalogItem` has a `$Hidden` switch parameter, but it is not passed to `New-RsDataSource`.
The tests for `Write-RsCatalogItem` didn't verify that items created were in fact hidden.
Specifically, "Should upload a local RsDataSource in Report Server" in context "Write-RsCatalogItem with hidden parameters" passed `$Hidden` to `Write-RsCatalogItem`, which created the data source, but the data source was not hidden.

Changes proposed in this pull request:
 - Added `$Hidden` parameter to `New-RsDataSource`, with doc comment
 - Changed `Write-RsCatalogItem` to pass `$Hidden` switch to `New-RsDataSource` 
 - Added test for `New-RsDataSource` with `$Hidden` switch parameter
 - Added assertions to all tests for `Write-RsCatalogItem` in context "Write-RsCatalogItem with hidden parameters",  to verify the item is indeed hidden
 
How to test this code:
 - Run pester test "Create RsDataSource with Hidden parameter" in `New-RsDataSource.Tests.ps1`
 - Run pester tests "Write-RsCatalogItem with hidden parameters" in `Write-RsCatalogItem.Tests.ps1`

Has been tested on (remove any that don't apply):
 - Powershell 7 using -UseWindowsPowerShell compatibility flag
 - Windows 10
 - SQL Server 2016
