### PR TITLE
Set Inherit Parent Policy to false

### DIFF
--- a/ReportingServicesTools/Functions/Security/Rest/Revoke-RsRestItemAccessPolicy.ps1
+++ b/ReportingServicesTools/Functions/Security/Rest/Revoke-RsRestItemAccessPolicy.ps1
@@ -120,6 +120,7 @@ function Revoke-RsRestItemAccessPolicy
             }
             
             $response.Policies = @([PSCustomObject]$response.Policies | WHERE {$_.groupusername -ne $Identity})
+            $response.InheritParentPolicy=$false
 
             $payloadJson = $response | ConvertTo-Json -Depth 15
             Write-Verbose "$payloadJson"


### PR DESCRIPTION
Without setting this property to false, this function will not work on objects that have 'InheritParentPolicy' set to true. It sets to false when granting permissions (in Grant RsRestItemAccessPolicy), but does not set to false in this one. In any case, when changing permissions, granting or revoking, the inheritence should be set to false as per the behaviour of the PBIRS app.

Fixes # .

Changes proposed in this pull request:
 - 
 - 
 - 

How to test this code:
 - 
 - 
 - 

Has been tested on (remove any that don't apply):
 - Powershell 3 and above
 - Windows 7 and above
 - SQL Server 2012 and above
