### PR TITLE
fix: Add -UseBasicParsing to all Invoke-WebRequest calls

### DIFF
--- a/ReportingServicesTools/Functions/CatalogItems/Rest/Get-RsRestFolderContent.ps1
+++ b/ReportingServicesTools/Functions/CatalogItems/Rest/Get-RsRestFolderContent.ps1
@@ -78,11 +78,11 @@ function Get-RsRestFolderContent
             $url = [String]::Format($catalogItemsUri, $RsFolder)
             if ($Credential -ne $null)
             {
-                $response = Invoke-WebRequest -Uri $url -Method Get -WebSession $WebSession -Credential $Credential -Verbose:$false
+                $response = Invoke-WebRequest -Uri $url -Method Get -WebSession $WebSession -Credential $Credential -UseBasicParsing -Verbose:$false
             }
             else
             {
-                $response = Invoke-WebRequest -Uri $url -Method Get -WebSession $WebSession -UseDefaultCredentials -Verbose:$false
+                $response = Invoke-WebRequest -Uri $url -Method Get -WebSession $WebSession -UseDefaultCredentials -UseBasicParsing -Verbose:$false
             }
 
             $catalogItems = (ConvertFrom-Json $response.Content).value

--- a/ReportingServicesTools/Functions/CatalogItems/Rest/Get-RsRestItem.ps1
+++ b/ReportingServicesTools/Functions/CatalogItems/Rest/Get-RsRestItem.ps1
@@ -76,11 +76,11 @@ function Get-RsRestItem
             $catalogItemsUri = [String]::Format($catalogItemsUri, $RsItem)
             if ($Credential -ne $null)
             {
-                $response = Invoke-WebRequest -Uri $catalogItemsUri -Method Get -WebSession $WebSession -Credential $Credential -Verbose:$false
+                $response = Invoke-WebRequest -Uri $catalogItemsUri -Method Get -WebSession $WebSession -Credential $Credential -UseBasicParsing -Verbose:$false
             }
             else
             {
-                $response = Invoke-WebRequest -Uri $catalogItemsUri -Method Get -WebSession $WebSession -UseDefaultCredentials -Verbose:$false
+                $response = Invoke-WebRequest -Uri $catalogItemsUri -Method Get -WebSession $WebSession -UseDefaultCredentials -UseBasicParsing -Verbose:$false
             }
 
             $item = ConvertFrom-Json $response.Content

--- a/ReportingServicesTools/Functions/CatalogItems/Rest/Get-RsRestItemDataModelParameters.ps1
+++ b/ReportingServicesTools/Functions/CatalogItems/Rest/Get-RsRestItemDataModelParameters.ps1
@@ -84,11 +84,11 @@ function Get-RsRestItemDataModelParameter
             $catalogItemsUri = [String]::Format($catalogItemsUri, $RsItem)
             if ($Credential -ne $null)
             {
-                $response = Invoke-WebRequest -Uri $catalogItemsUri -Method Get -WebSession $WebSession -Credential $Credential -Verbose:$false
+                $response = Invoke-WebRequest -Uri $catalogItemsUri -Method Get -WebSession $WebSession -Credential $Credential -UseBasicParsing -Verbose:$false
             }
             else
             {
-                $response = Invoke-WebRequest -Uri $catalogItemsUri -Method Get -WebSession $WebSession -UseDefaultCredentials -Verbose:$false
+                $response = Invoke-WebRequest -Uri $catalogItemsUri -Method Get -WebSession $WebSession -UseDefaultCredentials -UseBasicParsing -Verbose:$false
             }
 
             $item = ConvertFrom-Json $response.Content
@@ -99,11 +99,11 @@ function Get-RsRestItemDataModelParameter
 
             if ($Credential -ne $null)
             {
-                $paramResponse = Invoke-WebRequest -Uri $parametersUri -Method Get -WebSession $WebSession -Credential $Credential -Verbose:$false
+                $paramResponse = Invoke-WebRequest -Uri $parametersUri -Method Get -WebSession $WebSession -Credential $Credential -UseBasicParsing -Verbose:$false
             }
             else
             {
-                $paramResponse = Invoke-WebRequest -Uri $parametersUri -Method Get -WebSession $WebSession -UseDefaultCredentials -Verbose:$false
+                $paramResponse = Invoke-WebRequest -Uri $parametersUri -Method Get -WebSession $WebSession -UseDefaultCredentials -UseBasicParsing -Verbose:$false
             }
 
             Write-Verbose $paramResponse

--- a/ReportingServicesTools/Functions/CatalogItems/Rest/Get-RsRestItemDataSource.ps1
+++ b/ReportingServicesTools/Functions/CatalogItems/Rest/Get-RsRestItemDataSource.ps1
@@ -87,11 +87,11 @@ function Get-RsRestItemDataSource
             $catalogItemsUri = [String]::Format($catalogItemsUri, $RsItem)
             if ($Credential -ne $null)
             {
-                $response = Invoke-WebRequest -Uri $catalogItemsUri -Method Get -WebSession $WebSession -Credential $Credential -Verbose:$false
+                $response = Invoke-WebRequest -Uri $catalogItemsUri -Method Get -WebSession $WebSession -Credential $Credential -UseBasicParsing -Verbose:$false
             }
             else
             {
-                $response = Invoke-WebRequest -Uri $catalogItemsUri -Method Get -WebSession $WebSession -UseDefaultCredentials -Verbose:$false
+                $response = Invoke-WebRequest -Uri $catalogItemsUri -Method Get -WebSession $WebSession -UseDefaultCredentials -UseBasicParsing -Verbose:$false
             }
 
             $item = ConvertFrom-Json $response.Content
@@ -102,11 +102,11 @@ function Get-RsRestItemDataSource
 
             if ($Credential -ne $null)
             {
-                $response = Invoke-WebRequest -Uri $dataSourcesUri -Method Get -WebSession $WebSession -Credential $Credential -Verbose:$false
+                $response = Invoke-WebRequest -Uri $dataSourcesUri -Method Get -WebSession $WebSession -Credential $Credential -UseBasicParsing -Verbose:$false
             }
             else
             {
-                $response = Invoke-WebRequest -Uri $dataSourcesUri -Method Get -WebSession $WebSession -UseDefaultCredentials -Verbose:$false
+                $response = Invoke-WebRequest -Uri $dataSourcesUri -Method Get -WebSession $WebSession -UseDefaultCredentials -UseBasicParsing -Verbose:$false
             }
 
             $itemWithDataSources = ConvertFrom-Json $response.Content

--- a/ReportingServicesTools/Functions/CatalogItems/Rest/New-RsRestCacheRefreshPlan.ps1
+++ b/ReportingServicesTools/Functions/CatalogItems/Rest/New-RsRestCacheRefreshPlan.ps1
@@ -135,11 +135,11 @@ function New-RsRestCacheRefreshPlan
 
                 if ($Credential -ne $null)
                 {
-                    $response = Invoke-WebRequest -Uri $refreshplansUri -Method Post -WebSession $WebSession -Body ([System.Text.Encoding]::UTF8.GetBytes($payloadJson)) -ContentType "application/json" -Credential $Credential -Verbose:$false
+                    $response = Invoke-WebRequest -Uri $refreshplansUri -Method Post -WebSession $WebSession -Body ([System.Text.Encoding]::UTF8.GetBytes($payloadJson)) -ContentType "application/json" -Credential $Credential -UseBasicParsing -Verbose:$false
                 }
                 else
                 {
-                    $response = Invoke-WebRequest -Uri $refreshplansUri -Method Post -WebSession $WebSession -Body ([System.Text.Encoding]::UTF8.GetBytes($payloadJson)) -ContentType "application/json" -UseDefaultCredentials -Verbose:$false
+                    $response = Invoke-WebRequest -Uri $refreshplansUri -Method Post -WebSession $WebSession -Body ([System.Text.Encoding]::UTF8.GetBytes($payloadJson)) -ContentType "application/json" -UseDefaultCredentials -UseBasicParsing -Verbose:$false
                 }
 
                 Write-Verbose "Schedule payload for $RsItem was created successfully!"

--- a/ReportingServicesTools/Functions/CatalogItems/Rest/New-RsRestFolder.ps1
+++ b/ReportingServicesTools/Functions/CatalogItems/Rest/New-RsRestFolder.ps1
@@ -91,11 +91,11 @@ function New-RsRestFolder
 
             if ($Credential -ne $null)
             {
-                $response = Invoke-WebRequest -Uri $foldersUri -Method Post -WebSession $WebSession -Body ([System.Text.Encoding]::UTF8.GetBytes($payloadJson)) -ContentType "application/json" -Credential $Credential -Verbose:$false
+                $response = Invoke-WebRequest -Uri $foldersUri -Method Post -WebSession $WebSession -Body ([System.Text.Encoding]::UTF8.GetBytes($payloadJson)) -ContentType "application/json" -Credential $Credential -UseBasicParsing -Verbose:$false
             }
             else
             {
-                $response = Invoke-WebRequest -Uri $foldersUri -Method Post -WebSession $WebSession -Body ([System.Text.Encoding]::UTF8.GetBytes($payloadJson)) -ContentType "application/json" -UseDefaultCredentials -Verbose:$false
+                $response = Invoke-WebRequest -Uri $foldersUri -Method Post -WebSession $WebSession -Body ([System.Text.Encoding]::UTF8.GetBytes($payloadJson)) -ContentType "application/json" -UseDefaultCredentials -UseBasicParsing -Verbose:$false
             }
 
             Write-Verbose "Folder $TargetFolderPath was created successfully!"

--- a/ReportingServicesTools/Functions/CatalogItems/Rest/Out-RsRestCatalogItem.ps1
+++ b/ReportingServicesTools/Functions/CatalogItems/Rest/Out-RsRestCatalogItem.ps1
@@ -114,11 +114,11 @@ function Out-RsRestCatalogItem
                 $url = [string]::Format($catalogItemsByPathApi, $item)
                 if ($Credential -ne $null)
                 {
-                    $response = Invoke-WebRequest -Uri $url -Method Get -Credential $Credential -Verbose:$false
+                    $response = Invoke-WebRequest -Uri $url -Method Get -Credential $Credential -UseBasicParsing -Verbose:$false
                 }
                 else
                 {
-                    $response = Invoke-WebRequest -Uri $url -Method Get -UseDefaultCredentials -Verbose:$false
+                    $response = Invoke-WebRequest -Uri $url -Method Get -UseDefaultCredentials -UseBasicParsing -Verbose:$false
                 }
             }
             catch

--- a/ReportingServicesTools/Functions/CatalogItems/Rest/Out-RsRestCatalogItemId.ps1
+++ b/ReportingServicesTools/Functions/CatalogItems/Rest/Out-RsRestCatalogItemId.ps1
@@ -128,11 +128,11 @@ function Out-RsRestCatalogItemId
             $url = [string]::Format($catalogItemContentApi, $itemId)
             if ($Credential -ne $null)
             {
-                $response = Invoke-WebRequest -Uri $url -Method Get -Credential $Credential -Verbose:$false
+                $response = Invoke-WebRequest -Uri $url -Method Get -Credential $Credential -UseBasicParsing -Verbose:$false
             }
             else
             {
-                $response = Invoke-WebRequest -Uri $url -Method Get -UseDefaultCredentials -Verbose:$false
+                $response = Invoke-WebRequest -Uri $url -Method Get -UseDefaultCredentials -UseBasicParsing -Verbose:$false
             }
         }
         catch

--- a/ReportingServicesTools/Functions/CatalogItems/Rest/Out-RsRestFolderContent.ps1
+++ b/ReportingServicesTools/Functions/CatalogItems/Rest/Out-RsRestFolderContent.ps1
@@ -108,11 +108,11 @@ function Out-RsRestFolderContent
                 $url = [string]::Format($catalogItemsByPathApiV1, $RsFolder)
                 if ($Credential -ne $null)
                 {
-                    $response = Invoke-WebRequest -Uri $url -Method Get -Credential $Credential -Verbose:$false
+                    $response = Invoke-WebRequest -Uri $url -Method Get -Credential $Credential -UseBasicParsing -Verbose:$false
                 }
                 else
                 {
-                    $response = Invoke-WebRequest -Uri $url -Method Get -UseDefaultCredentials -Verbose:$false
+                    $response = Invoke-WebRequest -Uri $url -Method Get -UseDefaultCredentials -UseBasicParsing -Verbose:$false
                 }
             }
             catch
@@ -128,11 +128,11 @@ function Out-RsRestFolderContent
                 $url = [string]::Format($folderCatalogItemsApiV1, $folder.Id)
                 if ($Credential -ne $null)
                 {
-                    $response = Invoke-WebRequest -Uri $url -Method Get -Credential $Credential -Verbose:$false
+                    $response = Invoke-WebRequest -Uri $url -Method Get -Credential $Credential -UseBasicParsing -Verbose:$false
                 }
                 else
                 {
-                    $response = Invoke-WebRequest -Uri $url -Method Get -UseDefaultCredentials -Verbose:$false
+                    $response = Invoke-WebRequest -Uri $url -Method Get -UseDefaultCredentials -UseBasicParsing -Verbose:$false
                 }
             }
             catch
@@ -148,11 +148,11 @@ function Out-RsRestFolderContent
                 $url = [string]::Format($folderCatalogItemsApiLatest, $RsFolder)
                 if ($Credential -ne $null)
                 {
-                    $response = Invoke-WebRequest -Uri $url -Method Get -Credential $Credential -Verbose:$false
+                    $response = Invoke-WebRequest -Uri $url -Method Get -Credential $Credential -UseBasicParsing -Verbose:$false
                 }
                 else
                 {
-                    $response = Invoke-WebRequest -Uri $url -Method Get -UseDefaultCredentials -Verbose:$false
+                    $response = Invoke-WebRequest -Uri $url -Method Get -UseDefaultCredentials -UseBasicParsing -Verbose:$false
                 }
             }
             catch

--- a/ReportingServicesTools/Functions/CatalogItems/Rest/Remove-RsRestCatalogItem.ps1
+++ b/ReportingServicesTools/Functions/CatalogItems/Rest/Remove-RsRestCatalogItem.ps1
@@ -76,11 +76,11 @@ function Remove-RsRestCatalogItem
     
                 if ($Credential -ne $null)
                 {
-                    Invoke-WebRequest -Uri $catalogItemsUri -Method Delete -WebSession $WebSession -Credential $Credential -Verbose:$false | Out-Null
+                    Invoke-WebRequest -Uri $catalogItemsUri -Method Delete -WebSession $WebSession -Credential $Credential -UseBasicParsing -Verbose:$false | Out-Null
                 }
                 else
                 {
-                    Invoke-WebRequest -Uri $catalogItemsUri -Method Delete -WebSession $WebSession -UseDefaultCredentials -Verbose:$false | Out-Null
+                    Invoke-WebRequest -Uri $catalogItemsUri -Method Delete -WebSession $WebSession -UseDefaultCredentials -UseBasicParsing -Verbose:$false | Out-Null
                 }
     
                 Write-Verbose "Catalog item $RsItem was deleted successfully!"

--- a/ReportingServicesTools/Functions/CatalogItems/Rest/Set-RsRestItemDataModelParameters.ps1
+++ b/ReportingServicesTools/Functions/CatalogItems/Rest/Set-RsRestItemDataModelParameters.ps1
@@ -91,11 +91,11 @@ function Set-RsRestItemDataModelParameter
                 Write-Verbose "Updating data model parameters for $($RsItem)..."
                 if ($Credential -ne $null)
                 {
-                    Invoke-WebRequest -Uri $dataModelParametersUri -Method $method -Body ([System.Text.Encoding]::UTF8.GetBytes($payloadJson)) -ContentType "application/json" -WebSession $WebSession -Credential $Credential -Verbose:$false | Out-Null
+                    Invoke-WebRequest -Uri $dataModelParametersUri -Method $method -Body ([System.Text.Encoding]::UTF8.GetBytes($payloadJson)) -ContentType "application/json" -WebSession $WebSession -Credential $Credential -UseBasicParsing -Verbose:$false | Out-Null
                 }
                 else
                 {
-                    Invoke-WebRequest -Uri $dataModelParametersUri -Method $method -Body ([System.Text.Encoding]::UTF8.GetBytes($payloadJson)) -ContentType "application/json" -WebSession $WebSession -UseDefaultCredentials -Verbose:$false | Out-Null
+                    Invoke-WebRequest -Uri $dataModelParametersUri -Method $method -Body ([System.Text.Encoding]::UTF8.GetBytes($payloadJson)) -ContentType "application/json" -WebSession $WebSession -UseDefaultCredentials -UseBasicParsing -Verbose:$false | Out-Null
                 }
                 Write-Verbose "Data model parameters were updated successfully!"
             }

--- a/ReportingServicesTools/Functions/CatalogItems/Rest/Set-RsRestItemDataSource.ps1
+++ b/ReportingServicesTools/Functions/CatalogItems/Rest/Set-RsRestItemDataSource.ps1
@@ -238,11 +238,11 @@ function Set-RsRestItemDataSource
                 Write-Verbose "Updating data sources for $($RsItem)..."
                 if ($Credential -ne $null)
                 {
-                    Invoke-WebRequest -Uri $dataSourcesUri -Method $method -Body ([System.Text.Encoding]::UTF8.GetBytes($payloadJson)) -ContentType "application/json" -WebSession $WebSession -Credential $Credential -Verbose:$false | Out-Null
+                    Invoke-WebRequest -Uri $dataSourcesUri -Method $method -Body ([System.Text.Encoding]::UTF8.GetBytes($payloadJson)) -ContentType "application/json" -WebSession $WebSession -Credential $Credential -UseBasicParsing -Verbose:$false | Out-Null
                 }
                 else
                 {
-                    Invoke-WebRequest -Uri $dataSourcesUri -Method $method -Body ([System.Text.Encoding]::UTF8.GetBytes($payloadJson)) -ContentType "application/json" -WebSession $WebSession -UseDefaultCredentials -Verbose:$false | Out-Null
+                    Invoke-WebRequest -Uri $dataSourcesUri -Method $method -Body ([System.Text.Encoding]::UTF8.GetBytes($payloadJson)) -ContentType "application/json" -WebSession $WebSession -UseDefaultCredentials -UseBasicParsing -Verbose:$false | Out-Null
                 }
                 Write-Verbose "Data sources were updated successfully!"
             }

--- a/ReportingServicesTools/Functions/CatalogItems/Rest/Write-RsRestCatalogItem.ps1
+++ b/ReportingServicesTools/Functions/CatalogItems/Rest/Write-RsRestCatalogItem.ps1
@@ -324,11 +324,11 @@ function Write-RsRestCatalogItem
 
                 if ($Credential -ne $null)
                 {
-                    Invoke-WebRequest -Uri $endpointUrl -Method Post -WebSession $WebSession -Body $requestBody -ContentType $contentType -Credential $Credential -Verbose:$false | Out-Null
+                    Invoke-WebRequest -Uri $endpointUrl -Method Post -WebSession $WebSession -Body $requestBody -ContentType $contentType -Credential $Credential -UseBasicParsing -Verbose:$false | Out-Null
                 }
                 else
                 {
-                    Invoke-WebRequest -Uri $endpointUrl -Method Post -WebSession $WebSession -Body $requestBody -ContentType $contentType -UseDefaultCredentials -Verbose:$false | Out-Null
+                    Invoke-WebRequest -Uri $endpointUrl -Method Post -WebSession $WebSession -Body $requestBody -ContentType $contentType -UseDefaultCredentials -UseBasicParsing -Verbose:$false | Out-Null
                 }
 
                 Write-Verbose "$EntirePath was uploaded to $RsFolder successfully!"
@@ -343,11 +343,11 @@ function Write-RsRestCatalogItem
                         $uri = [String]::Format($catalogItemsByPathApi, $itemPath)
                         if ($Credential -ne $null)
                         {
-                            $response = Invoke-WebRequest -Uri $uri -Method Get -WebSession $WebSession -Credential $Credential -Verbose:$false
+                            $response = Invoke-WebRequest -Uri $uri -Method Get -WebSession $WebSession -Credential $Credential -UseBasicParsing -Verbose:$false
                         }
                         else
                         {
-                            $response = Invoke-WebRequest -Uri $uri -Method Get -WebSession $WebSession -UseDefaultCredentials -Verbose:$false
+                            $response = Invoke-WebRequest -Uri $uri -Method Get -WebSession $WebSession -UseDefaultCredentials -UseBasicParsing -Verbose:$false
                         }
 
                         # parsing response to get Id
@@ -358,11 +358,11 @@ function Write-RsRestCatalogItem
                         $uri = [String]::Format($catalogItemsUpdateUri, $itemId)
                         if ($Credential -ne $null)
                         {
-                            Invoke-WebRequest -Uri $uri -Method Put -WebSession $WebSession -Body ([System.Text.Encoding]::UTF8.GetBytes($payloadJson)) -ContentType "application/json" -Credential $Credential -Verbose:$false | Out-Null
+                            Invoke-WebRequest -Uri $uri -Method Put -WebSession $WebSession -Body ([System.Text.Encoding]::UTF8.GetBytes($payloadJson)) -ContentType "application/json" -Credential $Credential -UseBasicParsing -Verbose:$false | Out-Null
                         }
                         else
                         {
-                            Invoke-WebRequest -Uri $uri -Method Put -WebSession $WebSession -Body ([System.Text.Encoding]::UTF8.GetBytes($payloadJson)) -ContentType "application/json" -UseDefaultCredentials -Verbose:$false | Out-Null
+                            Invoke-WebRequest -Uri $uri -Method Put -WebSession $WebSession -Body ([System.Text.Encoding]::UTF8.GetBytes($payloadJson)) -ContentType "application/json" -UseDefaultCredentials -UseBasicParsing -Verbose:$false | Out-Null
                         }
                         Write-Verbose "$EntirePath was uploaded to $RsFolder successfully!"
                     }

--- a/ReportingServicesTools/Functions/CatalogItems/Rest/Write-RsRestFolderContent.ps1
+++ b/ReportingServicesTools/Functions/CatalogItems/Rest/Write-RsRestFolderContent.ps1
@@ -154,11 +154,11 @@ function Write-RsRestFolderContent
                     # Try to get folder info
                     if ($Credential -ne $null)
                     {
-                        $response = Invoke-WebRequest -Uri $uri -Method Get -WebSession $WebSession -Credential $Credential -Verbose:$false
+                        $response = Invoke-WebRequest -Uri $uri -Method Get -WebSession $WebSession -Credential $Credential -UseBasicParsing -Verbose:$false
                     }
                     else
                     {
-                        $response = Invoke-WebRequest -Uri $uri -Method Get -WebSession $WebSession -UseDefaultCredentials -Verbose:$false
+                        $response = Invoke-WebRequest -Uri $uri -Method Get -WebSession $WebSession -UseDefaultCredentials -UseBasicParsing -Verbose:$false
                     }
 
                     # parsing response to get folder name


### PR DESCRIPTION
Should fix #314

Fixes #314.

Changes proposed in this pull request:
 - Add `-UseBasicParsing` to all `Invoke-WebRequest` calls

How to test this code:
 - Use any of the `Rest` tools on a system running Powershell 5.1

Has NOT been tested:
 - Need to test