### PR TITLE
Fix error in Revoke-RsRestItemAccessPolicy

### DIFF
--- a/ReportingServicesTools/Functions/Security/Rest/Revoke-RsRestItemAccessPolicy.ps1
+++ b/ReportingServicesTools/Functions/Security/Rest/Revoke-RsRestItemAccessPolicy.ps1
@@ -124,7 +124,14 @@ function Revoke-RsRestItemAccessPolicy
 
             $payloadJson = $response | ConvertTo-Json -Depth 15
             Write-Verbose "$payloadJson"
-            $response = Invoke-RestMethod -Uri $PolicyUri -Method Put -WebSession $WebSession -UseDefaultCredentials -Body ([System.Text.Encoding]::UTF8.GetBytes($payloadJson)) -ContentType "application/json" -Verbose:$false
+			if ($Credential -ne $null)
+			{
+				$response = Invoke-RestMethod -Uri $PolicyUri -Method Put -WebSession $WebSession -Credential $Credential -Body ([System.Text.Encoding]::UTF8.GetBytes($payloadJson)) -ContentType "application/json"  -Verbose:$false
+			}
+			else
+			{
+				$response = Invoke-RestMethod -Uri $PolicyUri -Method Put -WebSession $WebSession -UseDefaultCredentials -Body ([System.Text.Encoding]::UTF8.GetBytes($payloadJson)) -ContentType "application/json" -Verbose:$false
+			}
 
             return $response
         }


### PR DESCRIPTION
Fix error 500 in Revoke-RsRestItemAccessPolicy when using credentials and not relying on  -UseDefaultCredentials

Has been tested on (remove any that don't apply):
 - Powershell 7 and above
 - Windows 10 and above
 - SQL Server 2019 and above
