### PR TITLE
Fix error 500 with *-RsRestItemAccessPolicy functions

### DIFF
--- a/ReportingServicesTools/Functions/Security/Rest/Get-RsRestItemAccessPolicy.ps1
+++ b/ReportingServicesTools/Functions/Security/Rest/Get-RsRestItemAccessPolicy.ps1
@@ -154,7 +154,14 @@ function Get-RsRestItemAccessPolicy
                     $PolicyUri = $ReportPortalUri + "api/$RestApiVersion/CatalogItems({0})/Policies"
                     $PolicyUri = [String]::Format($PolicyUri, $ChildItem.Id)
             
-                    $childPolicies = Invoke-RestMethod -Uri $PolicyUri -Method Get -WebSession $WebSession -UseDefaultCredentials -Verbose:$false
+                    if ($Credential -ne $null)
+                    {
+                        $childPolicies = Invoke-RestMethod -Uri $PolicyUri -Method Get -WebSession $WebSession -Credential $Credential -Verbose:$false
+                    }
+                    else
+                    {
+                        $childPolicies = Invoke-RestMethod -Uri $PolicyUri -Method Get -WebSession $WebSession -UseDefaultCredentials -Verbose:$false
+                    }
     
                     # Filter Polices by Identity
                     if($Identity) {

--- a/ReportingServicesTools/Functions/Security/Rest/Grant-RsRestItemAccessPolicy.ps1
+++ b/ReportingServicesTools/Functions/Security/Rest/Grant-RsRestItemAccessPolicy.ps1
@@ -147,8 +147,14 @@ function Grant-RsRestItemAccessPolicy
 
             $payloadJson = $response | ConvertTo-Json -Depth 15
             Write-Verbose "$payloadJson"
-            $response = Invoke-RestMethod -Uri $PolicyUri -Method Put -WebSession $WebSession -UseDefaultCredentials -Body ([System.Text.Encoding]::UTF8.GetBytes($payloadJson)) -ContentType "application/json" -Verbose:$false
-
+            if ($Credential -ne $null)
+            {
+                $response = Invoke-RestMethod -Uri $PolicyUri -Method Put -WebSession $WebSession -Credential $Credential -Body ([System.Text.Encoding]::UTF8.GetBytes($payloadJson)) -ContentType "application/json"  -Verbose:$false
+            }
+            else
+            {
+                $response = Invoke-RestMethod -Uri $PolicyUri -Method Put -WebSession $WebSession -UseDefaultCredentials -Body ([System.Text.Encoding]::UTF8.GetBytes($payloadJson)) -ContentType "application/json" -Verbose:$false
+            }
             return $response
         }
         catch

--- a/ReportingServicesTools/Functions/Security/Rest/Revoke-RsRestItemAccessPolicy.ps1
+++ b/ReportingServicesTools/Functions/Security/Rest/Revoke-RsRestItemAccessPolicy.ps1
@@ -124,14 +124,14 @@ function Revoke-RsRestItemAccessPolicy
 
             $payloadJson = $response | ConvertTo-Json -Depth 15
             Write-Verbose "$payloadJson"
-			if ($Credential -ne $null)
-			{
-				$response = Invoke-RestMethod -Uri $PolicyUri -Method Put -WebSession $WebSession -Credential $Credential -Body ([System.Text.Encoding]::UTF8.GetBytes($payloadJson)) -ContentType "application/json"  -Verbose:$false
-			}
-			else
-			{
-				$response = Invoke-RestMethod -Uri $PolicyUri -Method Put -WebSession $WebSession -UseDefaultCredentials -Body ([System.Text.Encoding]::UTF8.GetBytes($payloadJson)) -ContentType "application/json" -Verbose:$false
-			}
+            if ($Credential -ne $null)
+            {
+                $response = Invoke-RestMethod -Uri $PolicyUri -Method Put -WebSession $WebSession -Credential $Credential -Body ([System.Text.Encoding]::UTF8.GetBytes($payloadJson)) -ContentType "application/json"  -Verbose:$false
+            }
+            else
+            {
+                $response = Invoke-RestMethod -Uri $PolicyUri -Method Put -WebSession $WebSession -UseDefaultCredentials -Body ([System.Text.Encoding]::UTF8.GetBytes($payloadJson)) -ContentType "application/json" -Verbose:$false
+            }
 
             return $response
         }


### PR DESCRIPTION
Has been tested on (remove any that don't apply):
 - Powershell 7 and above
 - Windows 10 and above
 - SQL Server 2019 and above
