### PR TITLE
Fix #377 by loading creds from session unless provided

### DIFF
--- a/ReportingServicesTools/Functions/Admin/Rest/Get-RsRestPublicServerSetting.ps1
+++ b/ReportingServicesTools/Functions/Admin/Rest/Get-RsRestPublicServerSetting.ps1
@@ -54,10 +54,10 @@ function Get-RsRestPublicServerSetting
     Begin
     {
         $WebSession = New-RsRestSessionHelper -BoundParameters $PSBoundParameters
-		if ($Credential.Username -ne $WebSession.Credentials.Username) {
-			Write-Verbose "Using credentials from WebSession"
-			$Credential = New-Object System.Management.Automation.PSCredential "$($WebSession.Credentials.UserName)@$($WebSession.Credentials.Domain)", $WebSession.Credentials.SecurePassword 
-		}
+        if ($Credential.Username -ne $WebSession.Credentials.Username) {
+            Write-Verbose "Using credentials from WebSession"
+            $Credential = New-Object System.Management.Automation.PSCredential "$($WebSession.Credentials.UserName)@$($WebSession.Credentials.Domain)", $WebSession.Credentials.SecurePassword 
+        }
         $ReportPortalUri = Get-RsPortalUriHelper -WebSession $WebSession
         $systemPropertiesUri = $ReportPortalUri + "api/$RestApiVersion/System/Properties?properties={0}"
     }

--- a/ReportingServicesTools/Functions/Admin/Rest/Get-RsRestPublicServerSetting.ps1
+++ b/ReportingServicesTools/Functions/Admin/Rest/Get-RsRestPublicServerSetting.ps1
@@ -54,7 +54,7 @@ function Get-RsRestPublicServerSetting
     Begin
     {
         $WebSession = New-RsRestSessionHelper -BoundParameters $PSBoundParameters
-        if ($Credential.Username -ne $WebSession.Credentials.Username) {
+        if ($null -ne $WebSession.Credentials -and $null -eq $Credential) {
             Write-Verbose "Using credentials from WebSession"
             $Credential = New-Object System.Management.Automation.PSCredential "$($WebSession.Credentials.UserName)@$($WebSession.Credentials.Domain)", $WebSession.Credentials.SecurePassword 
         }

--- a/ReportingServicesTools/Functions/Admin/Rest/Get-RsRestPublicServerSetting.ps1
+++ b/ReportingServicesTools/Functions/Admin/Rest/Get-RsRestPublicServerSetting.ps1
@@ -56,7 +56,7 @@ function Get-RsRestPublicServerSetting
         $WebSession = New-RsRestSessionHelper -BoundParameters $PSBoundParameters
 		if ($Credential.Username -ne $WebSession.Credentials.Username) {
 			Write-Verbose "Using credentials from WebSession"
-			$Credential = New-Object System.Management.Automation.PSCredential "$($WebSession.Credentials.UserName)@$($WebSession.Credentials.Domain)", (ConvertTo-SecureString $WebSession.Credentials.Password -AsPlainText -Force)
+			$Credential = New-Object System.Management.Automation.PSCredential "$($WebSession.Credentials.UserName)@$($WebSession.Credentials.Domain)", $WebSession.Credentials.SecurePassword 
 		}
         $ReportPortalUri = Get-RsPortalUriHelper -WebSession $WebSession
         $systemPropertiesUri = $ReportPortalUri + "api/$RestApiVersion/System/Properties?properties={0}"

--- a/ReportingServicesTools/Functions/Admin/Rest/Get-RsRestPublicServerSetting.ps1
+++ b/ReportingServicesTools/Functions/Admin/Rest/Get-RsRestPublicServerSetting.ps1
@@ -54,6 +54,10 @@ function Get-RsRestPublicServerSetting
     Begin
     {
         $WebSession = New-RsRestSessionHelper -BoundParameters $PSBoundParameters
+		if ($Credential.Username -ne $WebSession.Credentials.Username) {
+			Write-Verbose "Using credentials from WebSession"
+			$Credential = New-Object System.Management.Automation.PSCredential "$($WebSession.Credentials.UserName)@$($WebSession.Credentials.Domain)", (ConvertTo-SecureString $WebSession.Credentials.Password -AsPlainText -Force)
+		}
         $ReportPortalUri = Get-RsPortalUriHelper -WebSession $WebSession
         $systemPropertiesUri = $ReportPortalUri + "api/$RestApiVersion/System/Properties?properties={0}"
     }

--- a/ReportingServicesTools/Functions/CatalogItems/Rest/Get-RsRestCacheRefreshPlan.ps1
+++ b/ReportingServicesTools/Functions/CatalogItems/Rest/Get-RsRestCacheRefreshPlan.ps1
@@ -65,6 +65,10 @@ function Get-RsRestCacheRefreshPlan
     Begin
     {
         $WebSession = New-RsRestSessionHelper -BoundParameters $PSBoundParameters
+		if ($Credential.Username -ne $WebSession.Credentials.Username) {
+			Write-Verbose "Using credentials from WebSession"
+			$Credential = New-Object System.Management.Automation.PSCredential "$($WebSession.Credentials.UserName)@$($WebSession.Credentials.Domain)", (ConvertTo-SecureString $WebSession.Credentials.Password -AsPlainText -Force)
+		}
         $ReportPortalUri = Get-RsPortalUriHelper -WebSession $WebSession
         $CacheRefreshPlanUri = $ReportPortalUri + "api/$RestApiVersion/PowerBIReports({0})/CacheRefreshPlans"
     }

--- a/ReportingServicesTools/Functions/CatalogItems/Rest/Get-RsRestCacheRefreshPlan.ps1
+++ b/ReportingServicesTools/Functions/CatalogItems/Rest/Get-RsRestCacheRefreshPlan.ps1
@@ -65,7 +65,7 @@ function Get-RsRestCacheRefreshPlan
     Begin
     {
         $WebSession = New-RsRestSessionHelper -BoundParameters $PSBoundParameters
-        if ($Credential.Username -ne $WebSession.Credentials.Username) {
+        if ($null -ne $WebSession.Credentials -and $null -eq $Credential) {
             Write-Verbose "Using credentials from WebSession"
             $Credential = New-Object System.Management.Automation.PSCredential "$($WebSession.Credentials.UserName)@$($WebSession.Credentials.Domain)", $WebSession.Credentials.SecurePassword 
         }

--- a/ReportingServicesTools/Functions/CatalogItems/Rest/Get-RsRestCacheRefreshPlan.ps1
+++ b/ReportingServicesTools/Functions/CatalogItems/Rest/Get-RsRestCacheRefreshPlan.ps1
@@ -67,7 +67,7 @@ function Get-RsRestCacheRefreshPlan
         $WebSession = New-RsRestSessionHelper -BoundParameters $PSBoundParameters
 		if ($Credential.Username -ne $WebSession.Credentials.Username) {
 			Write-Verbose "Using credentials from WebSession"
-			$Credential = New-Object System.Management.Automation.PSCredential "$($WebSession.Credentials.UserName)@$($WebSession.Credentials.Domain)", (ConvertTo-SecureString $WebSession.Credentials.Password -AsPlainText -Force)
+			$Credential = New-Object System.Management.Automation.PSCredential "$($WebSession.Credentials.UserName)@$($WebSession.Credentials.Domain)", $WebSession.Credentials.SecurePassword 
 		}
         $ReportPortalUri = Get-RsPortalUriHelper -WebSession $WebSession
         $CacheRefreshPlanUri = $ReportPortalUri + "api/$RestApiVersion/PowerBIReports({0})/CacheRefreshPlans"

--- a/ReportingServicesTools/Functions/CatalogItems/Rest/Get-RsRestCacheRefreshPlan.ps1
+++ b/ReportingServicesTools/Functions/CatalogItems/Rest/Get-RsRestCacheRefreshPlan.ps1
@@ -65,10 +65,10 @@ function Get-RsRestCacheRefreshPlan
     Begin
     {
         $WebSession = New-RsRestSessionHelper -BoundParameters $PSBoundParameters
-		if ($Credential.Username -ne $WebSession.Credentials.Username) {
-			Write-Verbose "Using credentials from WebSession"
-			$Credential = New-Object System.Management.Automation.PSCredential "$($WebSession.Credentials.UserName)@$($WebSession.Credentials.Domain)", $WebSession.Credentials.SecurePassword 
-		}
+        if ($Credential.Username -ne $WebSession.Credentials.Username) {
+            Write-Verbose "Using credentials from WebSession"
+            $Credential = New-Object System.Management.Automation.PSCredential "$($WebSession.Credentials.UserName)@$($WebSession.Credentials.Domain)", $WebSession.Credentials.SecurePassword 
+        }
         $ReportPortalUri = Get-RsPortalUriHelper -WebSession $WebSession
         $CacheRefreshPlanUri = $ReportPortalUri + "api/$RestApiVersion/PowerBIReports({0})/CacheRefreshPlans"
     }

--- a/ReportingServicesTools/Functions/CatalogItems/Rest/Get-RsRestCacheRefreshPlanHistory.ps1
+++ b/ReportingServicesTools/Functions/CatalogItems/Rest/Get-RsRestCacheRefreshPlanHistory.ps1
@@ -84,10 +84,10 @@ function Get-RsRestCacheRefreshPlanHistory
     Begin
     {
         $WebSession = New-RsRestSessionHelper -BoundParameters $PSBoundParameters
-		if ($Credential.Username -ne $WebSession.Credentials.Username) {
-			Write-Verbose "Using credentials from WebSession"
-			$Credential = New-Object System.Management.Automation.PSCredential "$($WebSession.Credentials.UserName)@$($WebSession.Credentials.Domain)", $WebSession.Credentials.SecurePassword 
-		}
+        if ($Credential.Username -ne $WebSession.Credentials.Username) {
+            Write-Verbose "Using credentials from WebSession"
+            $Credential = New-Object System.Management.Automation.PSCredential "$($WebSession.Credentials.UserName)@$($WebSession.Credentials.Domain)", $WebSession.Credentials.SecurePassword 
+        }
         $ReportPortalUri = Get-RsPortalUriHelper -WebSession $WebSession
     }
     Process

--- a/ReportingServicesTools/Functions/CatalogItems/Rest/Get-RsRestCacheRefreshPlanHistory.ps1
+++ b/ReportingServicesTools/Functions/CatalogItems/Rest/Get-RsRestCacheRefreshPlanHistory.ps1
@@ -84,7 +84,7 @@ function Get-RsRestCacheRefreshPlanHistory
     Begin
     {
         $WebSession = New-RsRestSessionHelper -BoundParameters $PSBoundParameters
-        if ($Credential.Username -ne $WebSession.Credentials.Username) {
+        if ($null -ne $WebSession.Credentials -and $null -eq $Credential) {
             Write-Verbose "Using credentials from WebSession"
             $Credential = New-Object System.Management.Automation.PSCredential "$($WebSession.Credentials.UserName)@$($WebSession.Credentials.Domain)", $WebSession.Credentials.SecurePassword 
         }

--- a/ReportingServicesTools/Functions/CatalogItems/Rest/Get-RsRestCacheRefreshPlanHistory.ps1
+++ b/ReportingServicesTools/Functions/CatalogItems/Rest/Get-RsRestCacheRefreshPlanHistory.ps1
@@ -84,6 +84,10 @@ function Get-RsRestCacheRefreshPlanHistory
     Begin
     {
         $WebSession = New-RsRestSessionHelper -BoundParameters $PSBoundParameters
+		if ($Credential.Username -ne $WebSession.Credentials.Username) {
+			Write-Verbose "Using credentials from WebSession"
+			$Credential = New-Object System.Management.Automation.PSCredential "$($WebSession.Credentials.UserName)@$($WebSession.Credentials.Domain)", (ConvertTo-SecureString $WebSession.Credentials.Password -AsPlainText -Force)
+		}
         $ReportPortalUri = Get-RsPortalUriHelper -WebSession $WebSession
     }
     Process

--- a/ReportingServicesTools/Functions/CatalogItems/Rest/Get-RsRestCacheRefreshPlanHistory.ps1
+++ b/ReportingServicesTools/Functions/CatalogItems/Rest/Get-RsRestCacheRefreshPlanHistory.ps1
@@ -86,7 +86,7 @@ function Get-RsRestCacheRefreshPlanHistory
         $WebSession = New-RsRestSessionHelper -BoundParameters $PSBoundParameters
 		if ($Credential.Username -ne $WebSession.Credentials.Username) {
 			Write-Verbose "Using credentials from WebSession"
-			$Credential = New-Object System.Management.Automation.PSCredential "$($WebSession.Credentials.UserName)@$($WebSession.Credentials.Domain)", (ConvertTo-SecureString $WebSession.Credentials.Password -AsPlainText -Force)
+			$Credential = New-Object System.Management.Automation.PSCredential "$($WebSession.Credentials.UserName)@$($WebSession.Credentials.Domain)", $WebSession.Credentials.SecurePassword 
 		}
         $ReportPortalUri = Get-RsPortalUriHelper -WebSession $WebSession
     }

--- a/ReportingServicesTools/Functions/CatalogItems/Rest/Get-RsRestFolderContent.ps1
+++ b/ReportingServicesTools/Functions/CatalogItems/Rest/Get-RsRestFolderContent.ps1
@@ -67,6 +67,10 @@ function Get-RsRestFolderContent
     Begin
     {
         $WebSession = New-RsRestSessionHelper -BoundParameters $PSBoundParameters
+		if ($Credential.Username -ne $WebSession.Credentials.Username) {
+			Write-Verbose "Using credentials from WebSession"
+			$Credential = New-Object System.Management.Automation.PSCredential "$($WebSession.Credentials.UserName)@$($WebSession.Credentials.Domain)", (ConvertTo-SecureString $WebSession.Credentials.Password -AsPlainText -Force)
+		}
         $ReportPortalUri = Get-RsPortalUriHelper -WebSession $WebSession
         $catalogItemsUri = $ReportPortalUri + "api/$RestApiVersion/Folders(Path='{0}')/CatalogItems?`$expand=Properties"
     }

--- a/ReportingServicesTools/Functions/CatalogItems/Rest/Get-RsRestFolderContent.ps1
+++ b/ReportingServicesTools/Functions/CatalogItems/Rest/Get-RsRestFolderContent.ps1
@@ -67,10 +67,10 @@ function Get-RsRestFolderContent
     Begin
     {
         $WebSession = New-RsRestSessionHelper -BoundParameters $PSBoundParameters
-		if ($Credential.Username -ne $WebSession.Credentials.Username) {
-			Write-Verbose "Using credentials from WebSession"
-			$Credential = New-Object System.Management.Automation.PSCredential "$($WebSession.Credentials.UserName)@$($WebSession.Credentials.Domain)", $WebSession.Credentials.SecurePassword 
-		}
+        if ($Credential.Username -ne $WebSession.Credentials.Username) {
+            Write-Verbose "Using credentials from WebSession"
+            $Credential = New-Object System.Management.Automation.PSCredential "$($WebSession.Credentials.UserName)@$($WebSession.Credentials.Domain)", $WebSession.Credentials.SecurePassword 
+        }
         $ReportPortalUri = Get-RsPortalUriHelper -WebSession $WebSession
         $catalogItemsUri = $ReportPortalUri + "api/$RestApiVersion/Folders(Path='{0}')/CatalogItems?`$expand=Properties"
     }

--- a/ReportingServicesTools/Functions/CatalogItems/Rest/Get-RsRestFolderContent.ps1
+++ b/ReportingServicesTools/Functions/CatalogItems/Rest/Get-RsRestFolderContent.ps1
@@ -67,7 +67,7 @@ function Get-RsRestFolderContent
     Begin
     {
         $WebSession = New-RsRestSessionHelper -BoundParameters $PSBoundParameters
-        if ($Credential.Username -ne $WebSession.Credentials.Username) {
+        if ($null -ne $WebSession.Credentials -and $null -eq $Credential) {
             Write-Verbose "Using credentials from WebSession"
             $Credential = New-Object System.Management.Automation.PSCredential "$($WebSession.Credentials.UserName)@$($WebSession.Credentials.Domain)", $WebSession.Credentials.SecurePassword 
         }

--- a/ReportingServicesTools/Functions/CatalogItems/Rest/Get-RsRestFolderContent.ps1
+++ b/ReportingServicesTools/Functions/CatalogItems/Rest/Get-RsRestFolderContent.ps1
@@ -69,7 +69,7 @@ function Get-RsRestFolderContent
         $WebSession = New-RsRestSessionHelper -BoundParameters $PSBoundParameters
 		if ($Credential.Username -ne $WebSession.Credentials.Username) {
 			Write-Verbose "Using credentials from WebSession"
-			$Credential = New-Object System.Management.Automation.PSCredential "$($WebSession.Credentials.UserName)@$($WebSession.Credentials.Domain)", (ConvertTo-SecureString $WebSession.Credentials.Password -AsPlainText -Force)
+			$Credential = New-Object System.Management.Automation.PSCredential "$($WebSession.Credentials.UserName)@$($WebSession.Credentials.Domain)", $WebSession.Credentials.SecurePassword 
 		}
         $ReportPortalUri = Get-RsPortalUriHelper -WebSession $WebSession
         $catalogItemsUri = $ReportPortalUri + "api/$RestApiVersion/Folders(Path='{0}')/CatalogItems?`$expand=Properties"

--- a/ReportingServicesTools/Functions/CatalogItems/Rest/Get-RsRestItem.ps1
+++ b/ReportingServicesTools/Functions/CatalogItems/Rest/Get-RsRestItem.ps1
@@ -67,7 +67,7 @@ function Get-RsRestItem
         $WebSession = New-RsRestSessionHelper -BoundParameters $PSBoundParameters
 		if ($Credential.Username -ne $WebSession.Credentials.Username) {
 			Write-Verbose "Using credentials from WebSession"
-			$Credential = New-Object System.Management.Automation.PSCredential "$($WebSession.Credentials.UserName)@$($WebSession.Credentials.Domain)", (ConvertTo-SecureString $WebSession.Credentials.Password -AsPlainText -Force)
+			$Credential = New-Object System.Management.Automation.PSCredential "$($WebSession.Credentials.UserName)@$($WebSession.Credentials.Domain)", $WebSession.Credentials.SecurePassword 
 		}
         $ReportPortalUri = Get-RsPortalUriHelper -WebSession $WebSession
         $catalogItemsUri = $ReportPortalUri + "api/$RestApiVersion/CatalogItems(Path='{0}')"

--- a/ReportingServicesTools/Functions/CatalogItems/Rest/Get-RsRestItem.ps1
+++ b/ReportingServicesTools/Functions/CatalogItems/Rest/Get-RsRestItem.ps1
@@ -65,7 +65,7 @@ function Get-RsRestItem
     Begin
     {
         $WebSession = New-RsRestSessionHelper -BoundParameters $PSBoundParameters
-        if ($Credential.Username -ne $WebSession.Credentials.Username) {
+        if ($null -ne $WebSession.Credentials -and $null -eq $Credential) {
             Write-Verbose "Using credentials from WebSession"
             $Credential = New-Object System.Management.Automation.PSCredential "$($WebSession.Credentials.UserName)@$($WebSession.Credentials.Domain)", $WebSession.Credentials.SecurePassword 
         }

--- a/ReportingServicesTools/Functions/CatalogItems/Rest/Get-RsRestItem.ps1
+++ b/ReportingServicesTools/Functions/CatalogItems/Rest/Get-RsRestItem.ps1
@@ -65,10 +65,10 @@ function Get-RsRestItem
     Begin
     {
         $WebSession = New-RsRestSessionHelper -BoundParameters $PSBoundParameters
-		if ($Credential.Username -ne $WebSession.Credentials.Username) {
-			Write-Verbose "Using credentials from WebSession"
-			$Credential = New-Object System.Management.Automation.PSCredential "$($WebSession.Credentials.UserName)@$($WebSession.Credentials.Domain)", $WebSession.Credentials.SecurePassword 
-		}
+        if ($Credential.Username -ne $WebSession.Credentials.Username) {
+            Write-Verbose "Using credentials from WebSession"
+            $Credential = New-Object System.Management.Automation.PSCredential "$($WebSession.Credentials.UserName)@$($WebSession.Credentials.Domain)", $WebSession.Credentials.SecurePassword 
+        }
         $ReportPortalUri = Get-RsPortalUriHelper -WebSession $WebSession
         $catalogItemsUri = $ReportPortalUri + "api/$RestApiVersion/CatalogItems(Path='{0}')"
     }

--- a/ReportingServicesTools/Functions/CatalogItems/Rest/Get-RsRestItem.ps1
+++ b/ReportingServicesTools/Functions/CatalogItems/Rest/Get-RsRestItem.ps1
@@ -65,6 +65,10 @@ function Get-RsRestItem
     Begin
     {
         $WebSession = New-RsRestSessionHelper -BoundParameters $PSBoundParameters
+		if ($Credential.Username -ne $WebSession.Credentials.Username) {
+			Write-Verbose "Using credentials from WebSession"
+			$Credential = New-Object System.Management.Automation.PSCredential "$($WebSession.Credentials.UserName)@$($WebSession.Credentials.Domain)", (ConvertTo-SecureString $WebSession.Credentials.Password -AsPlainText -Force)
+		}
         $ReportPortalUri = Get-RsPortalUriHelper -WebSession $WebSession
         $catalogItemsUri = $ReportPortalUri + "api/$RestApiVersion/CatalogItems(Path='{0}')"
     }

--- a/ReportingServicesTools/Functions/CatalogItems/Rest/Get-RsRestItemDataModelParameters.ps1
+++ b/ReportingServicesTools/Functions/CatalogItems/Rest/Get-RsRestItemDataModelParameters.ps1
@@ -72,6 +72,10 @@ function Get-RsRestItemDataModelParameter
     Begin
     {
         $WebSession = New-RsRestSessionHelper -BoundParameters $PSBoundParameters
+		if ($Credential.Username -ne $WebSession.Credentials.Username) {
+			Write-Verbose "Using credentials from WebSession"
+			$Credential = New-Object System.Management.Automation.PSCredential "$($WebSession.Credentials.UserName)@$($WebSession.Credentials.Domain)", (ConvertTo-SecureString $WebSession.Credentials.Password -AsPlainText -Force)
+		}
         $ReportPortalUri = Get-RsPortalUriHelper -WebSession $WebSession
         $catalogItemsUri = $ReportPortalUri + "api/$RestApiVersion/CatalogItems(Path='{0}')"
         $parametersUri = $ReportPortalUri + "api/$RestApiVersion/{0}(Path='{1}')?`$expand=DataModelParameters"

--- a/ReportingServicesTools/Functions/CatalogItems/Rest/Get-RsRestItemDataModelParameters.ps1
+++ b/ReportingServicesTools/Functions/CatalogItems/Rest/Get-RsRestItemDataModelParameters.ps1
@@ -72,7 +72,7 @@ function Get-RsRestItemDataModelParameter
     Begin
     {
         $WebSession = New-RsRestSessionHelper -BoundParameters $PSBoundParameters
-        if ($Credential.Username -ne $WebSession.Credentials.Username) {
+        if ($null -ne $WebSession.Credentials -and $null -eq $Credential) {
             Write-Verbose "Using credentials from WebSession"
             $Credential = New-Object System.Management.Automation.PSCredential "$($WebSession.Credentials.UserName)@$($WebSession.Credentials.Domain)", $WebSession.Credentials.SecurePassword 
         }

--- a/ReportingServicesTools/Functions/CatalogItems/Rest/Get-RsRestItemDataModelParameters.ps1
+++ b/ReportingServicesTools/Functions/CatalogItems/Rest/Get-RsRestItemDataModelParameters.ps1
@@ -72,10 +72,10 @@ function Get-RsRestItemDataModelParameter
     Begin
     {
         $WebSession = New-RsRestSessionHelper -BoundParameters $PSBoundParameters
-		if ($Credential.Username -ne $WebSession.Credentials.Username) {
-			Write-Verbose "Using credentials from WebSession"
-			$Credential = New-Object System.Management.Automation.PSCredential "$($WebSession.Credentials.UserName)@$($WebSession.Credentials.Domain)", $WebSession.Credentials.SecurePassword 
-		}
+        if ($Credential.Username -ne $WebSession.Credentials.Username) {
+            Write-Verbose "Using credentials from WebSession"
+            $Credential = New-Object System.Management.Automation.PSCredential "$($WebSession.Credentials.UserName)@$($WebSession.Credentials.Domain)", $WebSession.Credentials.SecurePassword 
+        }
         $ReportPortalUri = Get-RsPortalUriHelper -WebSession $WebSession
         $catalogItemsUri = $ReportPortalUri + "api/$RestApiVersion/CatalogItems(Path='{0}')"
         $parametersUri = $ReportPortalUri + "api/$RestApiVersion/{0}(Path='{1}')?`$expand=DataModelParameters"

--- a/ReportingServicesTools/Functions/CatalogItems/Rest/Get-RsRestItemDataModelParameters.ps1
+++ b/ReportingServicesTools/Functions/CatalogItems/Rest/Get-RsRestItemDataModelParameters.ps1
@@ -74,7 +74,7 @@ function Get-RsRestItemDataModelParameter
         $WebSession = New-RsRestSessionHelper -BoundParameters $PSBoundParameters
 		if ($Credential.Username -ne $WebSession.Credentials.Username) {
 			Write-Verbose "Using credentials from WebSession"
-			$Credential = New-Object System.Management.Automation.PSCredential "$($WebSession.Credentials.UserName)@$($WebSession.Credentials.Domain)", (ConvertTo-SecureString $WebSession.Credentials.Password -AsPlainText -Force)
+			$Credential = New-Object System.Management.Automation.PSCredential "$($WebSession.Credentials.UserName)@$($WebSession.Credentials.Domain)", $WebSession.Credentials.SecurePassword 
 		}
         $ReportPortalUri = Get-RsPortalUriHelper -WebSession $WebSession
         $catalogItemsUri = $ReportPortalUri + "api/$RestApiVersion/CatalogItems(Path='{0}')"

--- a/ReportingServicesTools/Functions/CatalogItems/Rest/Get-RsRestItemDataSource.ps1
+++ b/ReportingServicesTools/Functions/CatalogItems/Rest/Get-RsRestItemDataSource.ps1
@@ -77,7 +77,7 @@ function Get-RsRestItemDataSource
         $WebSession = New-RsRestSessionHelper -BoundParameters $PSBoundParameters
 		if ($Credential.Username -ne $WebSession.Credentials.Username) {
 			Write-Verbose "Using credentials from WebSession"
-			$Credential = New-Object System.Management.Automation.PSCredential "$($WebSession.Credentials.UserName)@$($WebSession.Credentials.Domain)", (ConvertTo-SecureString $WebSession.Credentials.Password -AsPlainText -Force)
+			$Credential = New-Object System.Management.Automation.PSCredential "$($WebSession.Credentials.UserName)@$($WebSession.Credentials.Domain)", $WebSession.Credentials.SecurePassword 
 		}
         $ReportPortalUri = Get-RsPortalUriHelper -WebSession $WebSession
         $catalogItemsUri = $ReportPortalUri + "api/$RestApiVersion/CatalogItems(Path='{0}')"

--- a/ReportingServicesTools/Functions/CatalogItems/Rest/Get-RsRestItemDataSource.ps1
+++ b/ReportingServicesTools/Functions/CatalogItems/Rest/Get-RsRestItemDataSource.ps1
@@ -75,7 +75,7 @@ function Get-RsRestItemDataSource
     Begin
     {
         $WebSession = New-RsRestSessionHelper -BoundParameters $PSBoundParameters
-        if ($Credential.Username -ne $WebSession.Credentials.Username) {
+        if ($null -ne $WebSession.Credentials -and $null -eq $Credential) {
             Write-Verbose "Using credentials from WebSession"
             $Credential = New-Object System.Management.Automation.PSCredential "$($WebSession.Credentials.UserName)@$($WebSession.Credentials.Domain)", $WebSession.Credentials.SecurePassword 
         }

--- a/ReportingServicesTools/Functions/CatalogItems/Rest/Get-RsRestItemDataSource.ps1
+++ b/ReportingServicesTools/Functions/CatalogItems/Rest/Get-RsRestItemDataSource.ps1
@@ -75,6 +75,10 @@ function Get-RsRestItemDataSource
     Begin
     {
         $WebSession = New-RsRestSessionHelper -BoundParameters $PSBoundParameters
+		if ($Credential.Username -ne $WebSession.Credentials.Username) {
+			Write-Verbose "Using credentials from WebSession"
+			$Credential = New-Object System.Management.Automation.PSCredential "$($WebSession.Credentials.UserName)@$($WebSession.Credentials.Domain)", (ConvertTo-SecureString $WebSession.Credentials.Password -AsPlainText -Force)
+		}
         $ReportPortalUri = Get-RsPortalUriHelper -WebSession $WebSession
         $catalogItemsUri = $ReportPortalUri + "api/$RestApiVersion/CatalogItems(Path='{0}')"
         $dataSourcesUri = $ReportPortalUri + "api/$RestApiVersion/{0}(Path='{1}')?`$expand=DataSources"

--- a/ReportingServicesTools/Functions/CatalogItems/Rest/Get-RsRestItemDataSource.ps1
+++ b/ReportingServicesTools/Functions/CatalogItems/Rest/Get-RsRestItemDataSource.ps1
@@ -75,10 +75,10 @@ function Get-RsRestItemDataSource
     Begin
     {
         $WebSession = New-RsRestSessionHelper -BoundParameters $PSBoundParameters
-		if ($Credential.Username -ne $WebSession.Credentials.Username) {
-			Write-Verbose "Using credentials from WebSession"
-			$Credential = New-Object System.Management.Automation.PSCredential "$($WebSession.Credentials.UserName)@$($WebSession.Credentials.Domain)", $WebSession.Credentials.SecurePassword 
-		}
+        if ($Credential.Username -ne $WebSession.Credentials.Username) {
+            Write-Verbose "Using credentials from WebSession"
+            $Credential = New-Object System.Management.Automation.PSCredential "$($WebSession.Credentials.UserName)@$($WebSession.Credentials.Domain)", $WebSession.Credentials.SecurePassword 
+        }
         $ReportPortalUri = Get-RsPortalUriHelper -WebSession $WebSession
         $catalogItemsUri = $ReportPortalUri + "api/$RestApiVersion/CatalogItems(Path='{0}')"
         $dataSourcesUri = $ReportPortalUri + "api/$RestApiVersion/{0}(Path='{1}')?`$expand=DataSources"

--- a/ReportingServicesTools/Functions/CatalogItems/Rest/New-RsRestCacheRefreshPlan.ps1
+++ b/ReportingServicesTools/Functions/CatalogItems/Rest/New-RsRestCacheRefreshPlan.ps1
@@ -103,10 +103,10 @@ function New-RsRestCacheRefreshPlan
     Begin
     {
         $WebSession = New-RsRestSessionHelper -BoundParameters $PSBoundParameters
-		if ($Credential.Username -ne $WebSession.Credentials.Username) {
-			Write-Verbose "Using credentials from WebSession"
-			$Credential = New-Object System.Management.Automation.PSCredential "$($WebSession.Credentials.UserName)@$($WebSession.Credentials.Domain)", $WebSession.Credentials.SecurePassword 
-		}
+        if ($Credential.Username -ne $WebSession.Credentials.Username) {
+            Write-Verbose "Using credentials from WebSession"
+            $Credential = New-Object System.Management.Automation.PSCredential "$($WebSession.Credentials.UserName)@$($WebSession.Credentials.Domain)", $WebSession.Credentials.SecurePassword 
+        }
         $ReportPortalUri = Get-RsPortalUriHelper -WebSession $WebSession
         $refreshplansUri = $ReportPortalUri + "api/$RestApiVersion/CacheRefreshPlans"      
     }

--- a/ReportingServicesTools/Functions/CatalogItems/Rest/New-RsRestCacheRefreshPlan.ps1
+++ b/ReportingServicesTools/Functions/CatalogItems/Rest/New-RsRestCacheRefreshPlan.ps1
@@ -105,7 +105,7 @@ function New-RsRestCacheRefreshPlan
         $WebSession = New-RsRestSessionHelper -BoundParameters $PSBoundParameters
 		if ($Credential.Username -ne $WebSession.Credentials.Username) {
 			Write-Verbose "Using credentials from WebSession"
-			$Credential = New-Object System.Management.Automation.PSCredential "$($WebSession.Credentials.UserName)@$($WebSession.Credentials.Domain)", (ConvertTo-SecureString $WebSession.Credentials.Password -AsPlainText -Force)
+			$Credential = New-Object System.Management.Automation.PSCredential "$($WebSession.Credentials.UserName)@$($WebSession.Credentials.Domain)", $WebSession.Credentials.SecurePassword 
 		}
         $ReportPortalUri = Get-RsPortalUriHelper -WebSession $WebSession
         $refreshplansUri = $ReportPortalUri + "api/$RestApiVersion/CacheRefreshPlans"      

--- a/ReportingServicesTools/Functions/CatalogItems/Rest/New-RsRestCacheRefreshPlan.ps1
+++ b/ReportingServicesTools/Functions/CatalogItems/Rest/New-RsRestCacheRefreshPlan.ps1
@@ -103,6 +103,10 @@ function New-RsRestCacheRefreshPlan
     Begin
     {
         $WebSession = New-RsRestSessionHelper -BoundParameters $PSBoundParameters
+		if ($Credential.Username -ne $WebSession.Credentials.Username) {
+			Write-Verbose "Using credentials from WebSession"
+			$Credential = New-Object System.Management.Automation.PSCredential "$($WebSession.Credentials.UserName)@$($WebSession.Credentials.Domain)", (ConvertTo-SecureString $WebSession.Credentials.Password -AsPlainText -Force)
+		}
         $ReportPortalUri = Get-RsPortalUriHelper -WebSession $WebSession
         $refreshplansUri = $ReportPortalUri + "api/$RestApiVersion/CacheRefreshPlans"      
     }

--- a/ReportingServicesTools/Functions/CatalogItems/Rest/New-RsRestCacheRefreshPlan.ps1
+++ b/ReportingServicesTools/Functions/CatalogItems/Rest/New-RsRestCacheRefreshPlan.ps1
@@ -103,7 +103,7 @@ function New-RsRestCacheRefreshPlan
     Begin
     {
         $WebSession = New-RsRestSessionHelper -BoundParameters $PSBoundParameters
-        if ($Credential.Username -ne $WebSession.Credentials.Username) {
+        if ($null -ne $WebSession.Credentials -and $null -eq $Credential) {
             Write-Verbose "Using credentials from WebSession"
             $Credential = New-Object System.Management.Automation.PSCredential "$($WebSession.Credentials.UserName)@$($WebSession.Credentials.Domain)", $WebSession.Credentials.SecurePassword 
         }

--- a/ReportingServicesTools/Functions/CatalogItems/Rest/New-RsRestFolder.ps1
+++ b/ReportingServicesTools/Functions/CatalogItems/Rest/New-RsRestFolder.ps1
@@ -67,7 +67,7 @@ function New-RsRestFolder
         $WebSession = New-RsRestSessionHelper -BoundParameters $PSBoundParameters
 		if ($Credential.Username -ne $WebSession.Credentials.Username) {
 			Write-Verbose "Using credentials from WebSession"
-			$Credential = New-Object System.Management.Automation.PSCredential "$($WebSession.Credentials.UserName)@$($WebSession.Credentials.Domain)", (ConvertTo-SecureString $WebSession.Credentials.Password -AsPlainText -Force)
+			$Credential = New-Object System.Management.Automation.PSCredential "$($WebSession.Credentials.UserName)@$($WebSession.Credentials.Domain)", $WebSession.Credentials.SecurePassword 
 		}
         $ReportPortalUri = Get-RsPortalUriHelper -WebSession $WebSession
         $foldersUri = $ReportPortalUri + "api/$RestApiVersion/Folders"

--- a/ReportingServicesTools/Functions/CatalogItems/Rest/New-RsRestFolder.ps1
+++ b/ReportingServicesTools/Functions/CatalogItems/Rest/New-RsRestFolder.ps1
@@ -65,6 +65,10 @@ function New-RsRestFolder
     Begin
     {
         $WebSession = New-RsRestSessionHelper -BoundParameters $PSBoundParameters
+		if ($Credential.Username -ne $WebSession.Credentials.Username) {
+			Write-Verbose "Using credentials from WebSession"
+			$Credential = New-Object System.Management.Automation.PSCredential "$($WebSession.Credentials.UserName)@$($WebSession.Credentials.Domain)", (ConvertTo-SecureString $WebSession.Credentials.Password -AsPlainText -Force)
+		}
         $ReportPortalUri = Get-RsPortalUriHelper -WebSession $WebSession
         $foldersUri = $ReportPortalUri + "api/$RestApiVersion/Folders"
     }

--- a/ReportingServicesTools/Functions/CatalogItems/Rest/New-RsRestFolder.ps1
+++ b/ReportingServicesTools/Functions/CatalogItems/Rest/New-RsRestFolder.ps1
@@ -65,7 +65,7 @@ function New-RsRestFolder
     Begin
     {
         $WebSession = New-RsRestSessionHelper -BoundParameters $PSBoundParameters
-        if ($Credential.Username -ne $WebSession.Credentials.Username) {
+        if ($null -ne $WebSession.Credentials -and $null -eq $Credential) {
             Write-Verbose "Using credentials from WebSession"
             $Credential = New-Object System.Management.Automation.PSCredential "$($WebSession.Credentials.UserName)@$($WebSession.Credentials.Domain)", $WebSession.Credentials.SecurePassword 
         }

--- a/ReportingServicesTools/Functions/CatalogItems/Rest/New-RsRestFolder.ps1
+++ b/ReportingServicesTools/Functions/CatalogItems/Rest/New-RsRestFolder.ps1
@@ -65,10 +65,10 @@ function New-RsRestFolder
     Begin
     {
         $WebSession = New-RsRestSessionHelper -BoundParameters $PSBoundParameters
-		if ($Credential.Username -ne $WebSession.Credentials.Username) {
-			Write-Verbose "Using credentials from WebSession"
-			$Credential = New-Object System.Management.Automation.PSCredential "$($WebSession.Credentials.UserName)@$($WebSession.Credentials.Domain)", $WebSession.Credentials.SecurePassword 
-		}
+        if ($Credential.Username -ne $WebSession.Credentials.Username) {
+            Write-Verbose "Using credentials from WebSession"
+            $Credential = New-Object System.Management.Automation.PSCredential "$($WebSession.Credentials.UserName)@$($WebSession.Credentials.Domain)", $WebSession.Credentials.SecurePassword 
+        }
         $ReportPortalUri = Get-RsPortalUriHelper -WebSession $WebSession
         $foldersUri = $ReportPortalUri + "api/$RestApiVersion/Folders"
     }

--- a/ReportingServicesTools/Functions/CatalogItems/Rest/Out-RsRestCatalogItem.ps1
+++ b/ReportingServicesTools/Functions/CatalogItems/Rest/Out-RsRestCatalogItem.ps1
@@ -94,10 +94,10 @@ function Out-RsRestCatalogItem
     Begin
     {
         $WebSession = New-RsRestSessionHelper -BoundParameters $PSBoundParameters
-		if ($Credential.Username -ne $WebSession.Credentials.Username) {
-			Write-Verbose "Using credentials from WebSession"
-			$Credential = New-Object System.Management.Automation.PSCredential "$($WebSession.Credentials.UserName)@$($WebSession.Credentials.Domain)", $WebSession.Credentials.SecurePassword 
-		}
+        if ($Credential.Username -ne $WebSession.Credentials.Username) {
+            Write-Verbose "Using credentials from WebSession"
+            $Credential = New-Object System.Management.Automation.PSCredential "$($WebSession.Credentials.UserName)@$($WebSession.Credentials.Domain)", $WebSession.Credentials.SecurePassword 
+        }
         $ReportPortalUri = Get-RsPortalUriHelper -WebSession $WebSession
         if ($RestApiVersion -eq 'v1.0')
         {

--- a/ReportingServicesTools/Functions/CatalogItems/Rest/Out-RsRestCatalogItem.ps1
+++ b/ReportingServicesTools/Functions/CatalogItems/Rest/Out-RsRestCatalogItem.ps1
@@ -96,7 +96,7 @@ function Out-RsRestCatalogItem
         $WebSession = New-RsRestSessionHelper -BoundParameters $PSBoundParameters
 		if ($Credential.Username -ne $WebSession.Credentials.Username) {
 			Write-Verbose "Using credentials from WebSession"
-			$Credential = New-Object System.Management.Automation.PSCredential "$($WebSession.Credentials.UserName)@$($WebSession.Credentials.Domain)", (ConvertTo-SecureString $WebSession.Credentials.Password -AsPlainText -Force)
+			$Credential = New-Object System.Management.Automation.PSCredential "$($WebSession.Credentials.UserName)@$($WebSession.Credentials.Domain)", $WebSession.Credentials.SecurePassword 
 		}
         $ReportPortalUri = Get-RsPortalUriHelper -WebSession $WebSession
         if ($RestApiVersion -eq 'v1.0')

--- a/ReportingServicesTools/Functions/CatalogItems/Rest/Out-RsRestCatalogItem.ps1
+++ b/ReportingServicesTools/Functions/CatalogItems/Rest/Out-RsRestCatalogItem.ps1
@@ -94,6 +94,10 @@ function Out-RsRestCatalogItem
     Begin
     {
         $WebSession = New-RsRestSessionHelper -BoundParameters $PSBoundParameters
+		if ($Credential.Username -ne $WebSession.Credentials.Username) {
+			Write-Verbose "Using credentials from WebSession"
+			$Credential = New-Object System.Management.Automation.PSCredential "$($WebSession.Credentials.UserName)@$($WebSession.Credentials.Domain)", (ConvertTo-SecureString $WebSession.Credentials.Password -AsPlainText -Force)
+		}
         $ReportPortalUri = Get-RsPortalUriHelper -WebSession $WebSession
         if ($RestApiVersion -eq 'v1.0')
         {

--- a/ReportingServicesTools/Functions/CatalogItems/Rest/Out-RsRestCatalogItem.ps1
+++ b/ReportingServicesTools/Functions/CatalogItems/Rest/Out-RsRestCatalogItem.ps1
@@ -94,7 +94,7 @@ function Out-RsRestCatalogItem
     Begin
     {
         $WebSession = New-RsRestSessionHelper -BoundParameters $PSBoundParameters
-        if ($Credential.Username -ne $WebSession.Credentials.Username) {
+        if ($null -ne $WebSession.Credentials -and $null -eq $Credential) {
             Write-Verbose "Using credentials from WebSession"
             $Credential = New-Object System.Management.Automation.PSCredential "$($WebSession.Credentials.UserName)@$($WebSession.Credentials.Domain)", $WebSession.Credentials.SecurePassword 
         }

--- a/ReportingServicesTools/Functions/CatalogItems/Rest/Out-RsRestCatalogItemId.ps1
+++ b/ReportingServicesTools/Functions/CatalogItems/Rest/Out-RsRestCatalogItemId.ps1
@@ -64,10 +64,10 @@ function Out-RsRestCatalogItemId
     Begin
     {
         $WebSession = New-RsRestSessionHelper -BoundParameters $PSBoundParameters
-		if ($Credential.Username -ne $WebSession.Credentials.Username) {
-			Write-Verbose "Using credentials from WebSession"
-			$Credential = New-Object System.Management.Automation.PSCredential "$($WebSession.Credentials.UserName)@$($WebSession.Credentials.Domain)", $WebSession.Credentials.SecurePassword 
-		}
+        if ($Credential.Username -ne $WebSession.Credentials.Username) {
+            Write-Verbose "Using credentials from WebSession"
+            $Credential = New-Object System.Management.Automation.PSCredential "$($WebSession.Credentials.UserName)@$($WebSession.Credentials.Domain)", $WebSession.Credentials.SecurePassword 
+        }
         $ReportPortalUri = Get-RsPortalUriHelper -WebSession $WebSession
         $catalogItemContentApi = $ReportPortalUri + "api/$RestApiVersion/CatalogItems({0})/Content/`$value"
         $DestinationFullPath = Convert-Path -LiteralPath $Destination

--- a/ReportingServicesTools/Functions/CatalogItems/Rest/Out-RsRestCatalogItemId.ps1
+++ b/ReportingServicesTools/Functions/CatalogItems/Rest/Out-RsRestCatalogItemId.ps1
@@ -66,7 +66,7 @@ function Out-RsRestCatalogItemId
         $WebSession = New-RsRestSessionHelper -BoundParameters $PSBoundParameters
 		if ($Credential.Username -ne $WebSession.Credentials.Username) {
 			Write-Verbose "Using credentials from WebSession"
-			$Credential = New-Object System.Management.Automation.PSCredential "$($WebSession.Credentials.UserName)@$($WebSession.Credentials.Domain)", (ConvertTo-SecureString $WebSession.Credentials.Password -AsPlainText -Force)
+			$Credential = New-Object System.Management.Automation.PSCredential "$($WebSession.Credentials.UserName)@$($WebSession.Credentials.Domain)", $WebSession.Credentials.SecurePassword 
 		}
         $ReportPortalUri = Get-RsPortalUriHelper -WebSession $WebSession
         $catalogItemContentApi = $ReportPortalUri + "api/$RestApiVersion/CatalogItems({0})/Content/`$value"

--- a/ReportingServicesTools/Functions/CatalogItems/Rest/Out-RsRestCatalogItemId.ps1
+++ b/ReportingServicesTools/Functions/CatalogItems/Rest/Out-RsRestCatalogItemId.ps1
@@ -64,6 +64,10 @@ function Out-RsRestCatalogItemId
     Begin
     {
         $WebSession = New-RsRestSessionHelper -BoundParameters $PSBoundParameters
+		if ($Credential.Username -ne $WebSession.Credentials.Username) {
+			Write-Verbose "Using credentials from WebSession"
+			$Credential = New-Object System.Management.Automation.PSCredential "$($WebSession.Credentials.UserName)@$($WebSession.Credentials.Domain)", (ConvertTo-SecureString $WebSession.Credentials.Password -AsPlainText -Force)
+		}
         $ReportPortalUri = Get-RsPortalUriHelper -WebSession $WebSession
         $catalogItemContentApi = $ReportPortalUri + "api/$RestApiVersion/CatalogItems({0})/Content/`$value"
         $DestinationFullPath = Convert-Path -LiteralPath $Destination

--- a/ReportingServicesTools/Functions/CatalogItems/Rest/Out-RsRestCatalogItemId.ps1
+++ b/ReportingServicesTools/Functions/CatalogItems/Rest/Out-RsRestCatalogItemId.ps1
@@ -64,7 +64,7 @@ function Out-RsRestCatalogItemId
     Begin
     {
         $WebSession = New-RsRestSessionHelper -BoundParameters $PSBoundParameters
-        if ($Credential.Username -ne $WebSession.Credentials.Username) {
+        if ($null -ne $WebSession.Credentials -and $null -eq $Credential) {
             Write-Verbose "Using credentials from WebSession"
             $Credential = New-Object System.Management.Automation.PSCredential "$($WebSession.Credentials.UserName)@$($WebSession.Credentials.Domain)", $WebSession.Credentials.SecurePassword 
         }

--- a/ReportingServicesTools/Functions/CatalogItems/Rest/Out-RsRestFolderContent.ps1
+++ b/ReportingServicesTools/Functions/CatalogItems/Rest/Out-RsRestFolderContent.ps1
@@ -93,10 +93,10 @@ function Out-RsRestFolderContent
     Begin
     {
         $WebSession = New-RsRestSessionHelper -BoundParameters $PSBoundParameters
-		if ($Credential.Username -ne $WebSession.Credentials.Username) {
-			Write-Verbose "Using credentials from WebSession"
-			$Credential = New-Object System.Management.Automation.PSCredential "$($WebSession.Credentials.UserName)@$($WebSession.Credentials.Domain)", $WebSession.Credentials.SecurePassword 
-		}
+        if ($Credential.Username -ne $WebSession.Credentials.Username) {
+            Write-Verbose "Using credentials from WebSession"
+            $Credential = New-Object System.Management.Automation.PSCredential "$($WebSession.Credentials.UserName)@$($WebSession.Credentials.Domain)", $WebSession.Credentials.SecurePassword 
+        }
         $ReportPortalUri = Get-RsPortalUriHelper -WebSession $WebSession
         $catalogItemsByPathApiV1 = $ReportPortalUri + "api/v1.0/CatalogItemByPath(path=@path)?@path=%27{0}%27"
         $folderCatalogItemsApiV1 = $ReportPortalUri + "api/v1.0/CatalogItems({0})/Model.Folder/CatalogItems"

--- a/ReportingServicesTools/Functions/CatalogItems/Rest/Out-RsRestFolderContent.ps1
+++ b/ReportingServicesTools/Functions/CatalogItems/Rest/Out-RsRestFolderContent.ps1
@@ -95,7 +95,7 @@ function Out-RsRestFolderContent
         $WebSession = New-RsRestSessionHelper -BoundParameters $PSBoundParameters
 		if ($Credential.Username -ne $WebSession.Credentials.Username) {
 			Write-Verbose "Using credentials from WebSession"
-			$Credential = New-Object System.Management.Automation.PSCredential "$($WebSession.Credentials.UserName)@$($WebSession.Credentials.Domain)", (ConvertTo-SecureString $WebSession.Credentials.Password -AsPlainText -Force)
+			$Credential = New-Object System.Management.Automation.PSCredential "$($WebSession.Credentials.UserName)@$($WebSession.Credentials.Domain)", $WebSession.Credentials.SecurePassword 
 		}
         $ReportPortalUri = Get-RsPortalUriHelper -WebSession $WebSession
         $catalogItemsByPathApiV1 = $ReportPortalUri + "api/v1.0/CatalogItemByPath(path=@path)?@path=%27{0}%27"

--- a/ReportingServicesTools/Functions/CatalogItems/Rest/Out-RsRestFolderContent.ps1
+++ b/ReportingServicesTools/Functions/CatalogItems/Rest/Out-RsRestFolderContent.ps1
@@ -93,7 +93,7 @@ function Out-RsRestFolderContent
     Begin
     {
         $WebSession = New-RsRestSessionHelper -BoundParameters $PSBoundParameters
-        if ($Credential.Username -ne $WebSession.Credentials.Username) {
+        if ($null -ne $WebSession.Credentials -and $null -eq $Credential) {
             Write-Verbose "Using credentials from WebSession"
             $Credential = New-Object System.Management.Automation.PSCredential "$($WebSession.Credentials.UserName)@$($WebSession.Credentials.Domain)", $WebSession.Credentials.SecurePassword 
         }

--- a/ReportingServicesTools/Functions/CatalogItems/Rest/Out-RsRestFolderContent.ps1
+++ b/ReportingServicesTools/Functions/CatalogItems/Rest/Out-RsRestFolderContent.ps1
@@ -93,6 +93,10 @@ function Out-RsRestFolderContent
     Begin
     {
         $WebSession = New-RsRestSessionHelper -BoundParameters $PSBoundParameters
+		if ($Credential.Username -ne $WebSession.Credentials.Username) {
+			Write-Verbose "Using credentials from WebSession"
+			$Credential = New-Object System.Management.Automation.PSCredential "$($WebSession.Credentials.UserName)@$($WebSession.Credentials.Domain)", (ConvertTo-SecureString $WebSession.Credentials.Password -AsPlainText -Force)
+		}
         $ReportPortalUri = Get-RsPortalUriHelper -WebSession $WebSession
         $catalogItemsByPathApiV1 = $ReportPortalUri + "api/v1.0/CatalogItemByPath(path=@path)?@path=%27{0}%27"
         $folderCatalogItemsApiV1 = $ReportPortalUri + "api/v1.0/CatalogItems({0})/Model.Folder/CatalogItems"

--- a/ReportingServicesTools/Functions/CatalogItems/Rest/Remove-RsRestCacheRefreshPlan.ps1
+++ b/ReportingServicesTools/Functions/CatalogItems/Rest/Remove-RsRestCacheRefreshPlan.ps1
@@ -72,10 +72,10 @@ function Remove-RsRestCacheRefreshPlan {
     Begin
     {
         $WebSession = New-RsRestSessionHelper -BoundParameters $PSBoundParameters
-		if ($Credential.Username -ne $WebSession.Credentials.Username) {
-			Write-Verbose "Using credentials from WebSession"
-			$Credential = New-Object System.Management.Automation.PSCredential "$($WebSession.Credentials.UserName)@$($WebSession.Credentials.Domain)", $WebSession.Credentials.SecurePassword 
-		}
+        if ($Credential.Username -ne $WebSession.Credentials.Username) {
+            Write-Verbose "Using credentials from WebSession"
+            $Credential = New-Object System.Management.Automation.PSCredential "$($WebSession.Credentials.UserName)@$($WebSession.Credentials.Domain)", $WebSession.Credentials.SecurePassword 
+        }
         $ReportPortalUri = Get-RsPortalUriHelper -WebSession $WebSession
         $CacheRefreshPlansUri = $ReportPortalUri + "api/$RestApiVersion/CacheRefreshPlans({0})"
     }

--- a/ReportingServicesTools/Functions/CatalogItems/Rest/Remove-RsRestCacheRefreshPlan.ps1
+++ b/ReportingServicesTools/Functions/CatalogItems/Rest/Remove-RsRestCacheRefreshPlan.ps1
@@ -72,7 +72,7 @@ function Remove-RsRestCacheRefreshPlan {
     Begin
     {
         $WebSession = New-RsRestSessionHelper -BoundParameters $PSBoundParameters
-        if ($Credential.Username -ne $WebSession.Credentials.Username) {
+        if ($null -ne $WebSession.Credentials -and $null -eq $Credential) {
             Write-Verbose "Using credentials from WebSession"
             $Credential = New-Object System.Management.Automation.PSCredential "$($WebSession.Credentials.UserName)@$($WebSession.Credentials.Domain)", $WebSession.Credentials.SecurePassword 
         }

--- a/ReportingServicesTools/Functions/CatalogItems/Rest/Remove-RsRestCacheRefreshPlan.ps1
+++ b/ReportingServicesTools/Functions/CatalogItems/Rest/Remove-RsRestCacheRefreshPlan.ps1
@@ -72,6 +72,10 @@ function Remove-RsRestCacheRefreshPlan {
     Begin
     {
         $WebSession = New-RsRestSessionHelper -BoundParameters $PSBoundParameters
+		if ($Credential.Username -ne $WebSession.Credentials.Username) {
+			Write-Verbose "Using credentials from WebSession"
+			$Credential = New-Object System.Management.Automation.PSCredential "$($WebSession.Credentials.UserName)@$($WebSession.Credentials.Domain)", (ConvertTo-SecureString $WebSession.Credentials.Password -AsPlainText -Force)
+		}
         $ReportPortalUri = Get-RsPortalUriHelper -WebSession $WebSession
         $CacheRefreshPlansUri = $ReportPortalUri + "api/$RestApiVersion/CacheRefreshPlans({0})"
     }

--- a/ReportingServicesTools/Functions/CatalogItems/Rest/Remove-RsRestCacheRefreshPlan.ps1
+++ b/ReportingServicesTools/Functions/CatalogItems/Rest/Remove-RsRestCacheRefreshPlan.ps1
@@ -74,7 +74,7 @@ function Remove-RsRestCacheRefreshPlan {
         $WebSession = New-RsRestSessionHelper -BoundParameters $PSBoundParameters
 		if ($Credential.Username -ne $WebSession.Credentials.Username) {
 			Write-Verbose "Using credentials from WebSession"
-			$Credential = New-Object System.Management.Automation.PSCredential "$($WebSession.Credentials.UserName)@$($WebSession.Credentials.Domain)", (ConvertTo-SecureString $WebSession.Credentials.Password -AsPlainText -Force)
+			$Credential = New-Object System.Management.Automation.PSCredential "$($WebSession.Credentials.UserName)@$($WebSession.Credentials.Domain)", $WebSession.Credentials.SecurePassword 
 		}
         $ReportPortalUri = Get-RsPortalUriHelper -WebSession $WebSession
         $CacheRefreshPlansUri = $ReportPortalUri + "api/$RestApiVersion/CacheRefreshPlans({0})"

--- a/ReportingServicesTools/Functions/CatalogItems/Rest/Remove-RsRestCatalogItem.ps1
+++ b/ReportingServicesTools/Functions/CatalogItems/Rest/Remove-RsRestCatalogItem.ps1
@@ -57,6 +57,10 @@ function Remove-RsRestCatalogItem
     Begin
     {
         $WebSession = New-RsRestSessionHelper -BoundParameters $PSBoundParameters
+		if ($Credential.Username -ne $WebSession.Credentials.Username) {
+			Write-Verbose "Using credentials from WebSession"
+			$Credential = New-Object System.Management.Automation.PSCredential "$($WebSession.Credentials.UserName)@$($WebSession.Credentials.Domain)", (ConvertTo-SecureString $WebSession.Credentials.Password -AsPlainText -Force)
+		}
         $ReportPortalUri = Get-RsPortalUriHelper -WebSession $WebSession
         $catalogItemsUri = $ReportPortalUri + "api/$RestApiVersion/CatalogItems(Path='{0}')"
     }

--- a/ReportingServicesTools/Functions/CatalogItems/Rest/Remove-RsRestCatalogItem.ps1
+++ b/ReportingServicesTools/Functions/CatalogItems/Rest/Remove-RsRestCatalogItem.ps1
@@ -57,7 +57,7 @@ function Remove-RsRestCatalogItem
     Begin
     {
         $WebSession = New-RsRestSessionHelper -BoundParameters $PSBoundParameters
-        if ($Credential.Username -ne $WebSession.Credentials.Username) {
+        if ($null -ne $WebSession.Credentials -and $null -eq $Credential) {
             Write-Verbose "Using credentials from WebSession"
             $Credential = New-Object System.Management.Automation.PSCredential "$($WebSession.Credentials.UserName)@$($WebSession.Credentials.Domain)", $WebSession.Credentials.SecurePassword 
         }

--- a/ReportingServicesTools/Functions/CatalogItems/Rest/Remove-RsRestCatalogItem.ps1
+++ b/ReportingServicesTools/Functions/CatalogItems/Rest/Remove-RsRestCatalogItem.ps1
@@ -59,7 +59,7 @@ function Remove-RsRestCatalogItem
         $WebSession = New-RsRestSessionHelper -BoundParameters $PSBoundParameters
 		if ($Credential.Username -ne $WebSession.Credentials.Username) {
 			Write-Verbose "Using credentials from WebSession"
-			$Credential = New-Object System.Management.Automation.PSCredential "$($WebSession.Credentials.UserName)@$($WebSession.Credentials.Domain)", (ConvertTo-SecureString $WebSession.Credentials.Password -AsPlainText -Force)
+			$Credential = New-Object System.Management.Automation.PSCredential "$($WebSession.Credentials.UserName)@$($WebSession.Credentials.Domain)", $WebSession.Credentials.SecurePassword 
 		}
         $ReportPortalUri = Get-RsPortalUriHelper -WebSession $WebSession
         $catalogItemsUri = $ReportPortalUri + "api/$RestApiVersion/CatalogItems(Path='{0}')"

--- a/ReportingServicesTools/Functions/CatalogItems/Rest/Remove-RsRestCatalogItem.ps1
+++ b/ReportingServicesTools/Functions/CatalogItems/Rest/Remove-RsRestCatalogItem.ps1
@@ -57,10 +57,10 @@ function Remove-RsRestCatalogItem
     Begin
     {
         $WebSession = New-RsRestSessionHelper -BoundParameters $PSBoundParameters
-		if ($Credential.Username -ne $WebSession.Credentials.Username) {
-			Write-Verbose "Using credentials from WebSession"
-			$Credential = New-Object System.Management.Automation.PSCredential "$($WebSession.Credentials.UserName)@$($WebSession.Credentials.Domain)", $WebSession.Credentials.SecurePassword 
-		}
+        if ($Credential.Username -ne $WebSession.Credentials.Username) {
+            Write-Verbose "Using credentials from WebSession"
+            $Credential = New-Object System.Management.Automation.PSCredential "$($WebSession.Credentials.UserName)@$($WebSession.Credentials.Domain)", $WebSession.Credentials.SecurePassword 
+        }
         $ReportPortalUri = Get-RsPortalUriHelper -WebSession $WebSession
         $catalogItemsUri = $ReportPortalUri + "api/$RestApiVersion/CatalogItems(Path='{0}')"
     }

--- a/ReportingServicesTools/Functions/CatalogItems/Rest/Remove-RsRestFolder.ps1
+++ b/ReportingServicesTools/Functions/CatalogItems/Rest/Remove-RsRestFolder.ps1
@@ -57,6 +57,10 @@ function Remove-RsRestFolder
     Begin
     {
         $WebSession = New-RsRestSessionHelper -BoundParameters $PSBoundParameters
+		if ($Credential.Username -ne $WebSession.Credentials.Username) {
+			Write-Verbose "Using credentials from WebSession"
+			$Credential = New-Object System.Management.Automation.PSCredential "$($WebSession.Credentials.UserName)@$($WebSession.Credentials.Domain)", (ConvertTo-SecureString $WebSession.Credentials.Password -AsPlainText -Force)
+		}
         $ReportPortalUri = Get-RsPortalUriHelper -WebSession $WebSession
         $foldersUri = $ReportPortalUri + "api/$RestApiVersion/Folders(Path='{0}')"
     }

--- a/ReportingServicesTools/Functions/CatalogItems/Rest/Remove-RsRestFolder.ps1
+++ b/ReportingServicesTools/Functions/CatalogItems/Rest/Remove-RsRestFolder.ps1
@@ -57,10 +57,10 @@ function Remove-RsRestFolder
     Begin
     {
         $WebSession = New-RsRestSessionHelper -BoundParameters $PSBoundParameters
-		if ($Credential.Username -ne $WebSession.Credentials.Username) {
-			Write-Verbose "Using credentials from WebSession"
-			$Credential = New-Object System.Management.Automation.PSCredential "$($WebSession.Credentials.UserName)@$($WebSession.Credentials.Domain)", $WebSession.Credentials.SecurePassword 
-		}
+        if ($Credential.Username -ne $WebSession.Credentials.Username) {
+            Write-Verbose "Using credentials from WebSession"
+            $Credential = New-Object System.Management.Automation.PSCredential "$($WebSession.Credentials.UserName)@$($WebSession.Credentials.Domain)", $WebSession.Credentials.SecurePassword 
+        }
         $ReportPortalUri = Get-RsPortalUriHelper -WebSession $WebSession
         $foldersUri = $ReportPortalUri + "api/$RestApiVersion/Folders(Path='{0}')"
     }

--- a/ReportingServicesTools/Functions/CatalogItems/Rest/Remove-RsRestFolder.ps1
+++ b/ReportingServicesTools/Functions/CatalogItems/Rest/Remove-RsRestFolder.ps1
@@ -59,7 +59,7 @@ function Remove-RsRestFolder
         $WebSession = New-RsRestSessionHelper -BoundParameters $PSBoundParameters
 		if ($Credential.Username -ne $WebSession.Credentials.Username) {
 			Write-Verbose "Using credentials from WebSession"
-			$Credential = New-Object System.Management.Automation.PSCredential "$($WebSession.Credentials.UserName)@$($WebSession.Credentials.Domain)", (ConvertTo-SecureString $WebSession.Credentials.Password -AsPlainText -Force)
+			$Credential = New-Object System.Management.Automation.PSCredential "$($WebSession.Credentials.UserName)@$($WebSession.Credentials.Domain)", $WebSession.Credentials.SecurePassword 
 		}
         $ReportPortalUri = Get-RsPortalUriHelper -WebSession $WebSession
         $foldersUri = $ReportPortalUri + "api/$RestApiVersion/Folders(Path='{0}')"

--- a/ReportingServicesTools/Functions/CatalogItems/Rest/Remove-RsRestFolder.ps1
+++ b/ReportingServicesTools/Functions/CatalogItems/Rest/Remove-RsRestFolder.ps1
@@ -57,7 +57,7 @@ function Remove-RsRestFolder
     Begin
     {
         $WebSession = New-RsRestSessionHelper -BoundParameters $PSBoundParameters
-        if ($Credential.Username -ne $WebSession.Credentials.Username) {
+        if ($null -ne $WebSession.Credentials -and $null -eq $Credential) {
             Write-Verbose "Using credentials from WebSession"
             $Credential = New-Object System.Management.Automation.PSCredential "$($WebSession.Credentials.UserName)@$($WebSession.Credentials.Domain)", $WebSession.Credentials.SecurePassword 
         }

--- a/ReportingServicesTools/Functions/CatalogItems/Rest/Set-RsRestItemDataModelParameters.ps1
+++ b/ReportingServicesTools/Functions/CatalogItems/Rest/Set-RsRestItemDataModelParameters.ps1
@@ -66,10 +66,10 @@ function Set-RsRestItemDataModelParameter
     Begin
     {
         $WebSession = New-RsRestSessionHelper -BoundParameters $PSBoundParameters
-		if ($Credential.Username -ne $WebSession.Credentials.Username) {
-			Write-Verbose "Using credentials from WebSession"
-			$Credential = New-Object System.Management.Automation.PSCredential "$($WebSession.Credentials.UserName)@$($WebSession.Credentials.Domain)", $WebSession.Credentials.SecurePassword 
-		}
+        if ($Credential.Username -ne $WebSession.Credentials.Username) {
+            Write-Verbose "Using credentials from WebSession"
+            $Credential = New-Object System.Management.Automation.PSCredential "$($WebSession.Credentials.UserName)@$($WebSession.Credentials.Domain)", $WebSession.Credentials.SecurePassword 
+        }
         $ReportPortalUri = Get-RsPortalUriHelper -WebSession $WebSession
         $dataModelParametersUri = $ReportPortalUri + "api/$RestApiVersion/PowerBIReports(Path='{0}')/DataModelParameters"
     }

--- a/ReportingServicesTools/Functions/CatalogItems/Rest/Set-RsRestItemDataModelParameters.ps1
+++ b/ReportingServicesTools/Functions/CatalogItems/Rest/Set-RsRestItemDataModelParameters.ps1
@@ -66,7 +66,7 @@ function Set-RsRestItemDataModelParameter
     Begin
     {
         $WebSession = New-RsRestSessionHelper -BoundParameters $PSBoundParameters
-        if ($Credential.Username -ne $WebSession.Credentials.Username) {
+        if ($null -ne $WebSession.Credentials -and $null -eq $Credential) {
             Write-Verbose "Using credentials from WebSession"
             $Credential = New-Object System.Management.Automation.PSCredential "$($WebSession.Credentials.UserName)@$($WebSession.Credentials.Domain)", $WebSession.Credentials.SecurePassword 
         }

--- a/ReportingServicesTools/Functions/CatalogItems/Rest/Set-RsRestItemDataModelParameters.ps1
+++ b/ReportingServicesTools/Functions/CatalogItems/Rest/Set-RsRestItemDataModelParameters.ps1
@@ -66,6 +66,10 @@ function Set-RsRestItemDataModelParameter
     Begin
     {
         $WebSession = New-RsRestSessionHelper -BoundParameters $PSBoundParameters
+		if ($Credential.Username -ne $WebSession.Credentials.Username) {
+			Write-Verbose "Using credentials from WebSession"
+			$Credential = New-Object System.Management.Automation.PSCredential "$($WebSession.Credentials.UserName)@$($WebSession.Credentials.Domain)", (ConvertTo-SecureString $WebSession.Credentials.Password -AsPlainText -Force)
+		}
         $ReportPortalUri = Get-RsPortalUriHelper -WebSession $WebSession
         $dataModelParametersUri = $ReportPortalUri + "api/$RestApiVersion/PowerBIReports(Path='{0}')/DataModelParameters"
     }

--- a/ReportingServicesTools/Functions/CatalogItems/Rest/Set-RsRestItemDataModelParameters.ps1
+++ b/ReportingServicesTools/Functions/CatalogItems/Rest/Set-RsRestItemDataModelParameters.ps1
@@ -68,7 +68,7 @@ function Set-RsRestItemDataModelParameter
         $WebSession = New-RsRestSessionHelper -BoundParameters $PSBoundParameters
 		if ($Credential.Username -ne $WebSession.Credentials.Username) {
 			Write-Verbose "Using credentials from WebSession"
-			$Credential = New-Object System.Management.Automation.PSCredential "$($WebSession.Credentials.UserName)@$($WebSession.Credentials.Domain)", (ConvertTo-SecureString $WebSession.Credentials.Password -AsPlainText -Force)
+			$Credential = New-Object System.Management.Automation.PSCredential "$($WebSession.Credentials.UserName)@$($WebSession.Credentials.Domain)", $WebSession.Credentials.SecurePassword 
 		}
         $ReportPortalUri = Get-RsPortalUriHelper -WebSession $WebSession
         $dataModelParametersUri = $ReportPortalUri + "api/$RestApiVersion/PowerBIReports(Path='{0}')/DataModelParameters"

--- a/ReportingServicesTools/Functions/CatalogItems/Rest/Set-RsRestItemDataSource.ps1
+++ b/ReportingServicesTools/Functions/CatalogItems/Rest/Set-RsRestItemDataSource.ps1
@@ -140,7 +140,7 @@ function Set-RsRestItemDataSource
         $WebSession = New-RsRestSessionHelper -BoundParameters $PSBoundParameters
 		if ($Credential.Username -ne $WebSession.Credentials.Username) {
 			Write-Verbose "Using credentials from WebSession"
-			$Credential = New-Object System.Management.Automation.PSCredential "$($WebSession.Credentials.UserName)@$($WebSession.Credentials.Domain)", (ConvertTo-SecureString $WebSession.Credentials.Password -AsPlainText -Force)
+			$Credential = New-Object System.Management.Automation.PSCredential "$($WebSession.Credentials.UserName)@$($WebSession.Credentials.Domain)", $WebSession.Credentials.SecurePassword 
 		}
         $ReportPortalUri = Get-RsPortalUriHelper -WebSession $WebSession
         $dataSourcesUri = $ReportPortalUri + "api/$RestApiVersion/{0}(Path='{1}')/DataSources"

--- a/ReportingServicesTools/Functions/CatalogItems/Rest/Set-RsRestItemDataSource.ps1
+++ b/ReportingServicesTools/Functions/CatalogItems/Rest/Set-RsRestItemDataSource.ps1
@@ -138,6 +138,10 @@ function Set-RsRestItemDataSource
     Begin
     {
         $WebSession = New-RsRestSessionHelper -BoundParameters $PSBoundParameters
+		if ($Credential.Username -ne $WebSession.Credentials.Username) {
+			Write-Verbose "Using credentials from WebSession"
+			$Credential = New-Object System.Management.Automation.PSCredential "$($WebSession.Credentials.UserName)@$($WebSession.Credentials.Domain)", (ConvertTo-SecureString $WebSession.Credentials.Password -AsPlainText -Force)
+		}
         $ReportPortalUri = Get-RsPortalUriHelper -WebSession $WebSession
         $dataSourcesUri = $ReportPortalUri + "api/$RestApiVersion/{0}(Path='{1}')/DataSources"
     }

--- a/ReportingServicesTools/Functions/CatalogItems/Rest/Set-RsRestItemDataSource.ps1
+++ b/ReportingServicesTools/Functions/CatalogItems/Rest/Set-RsRestItemDataSource.ps1
@@ -138,10 +138,10 @@ function Set-RsRestItemDataSource
     Begin
     {
         $WebSession = New-RsRestSessionHelper -BoundParameters $PSBoundParameters
-		if ($Credential.Username -ne $WebSession.Credentials.Username) {
-			Write-Verbose "Using credentials from WebSession"
-			$Credential = New-Object System.Management.Automation.PSCredential "$($WebSession.Credentials.UserName)@$($WebSession.Credentials.Domain)", $WebSession.Credentials.SecurePassword 
-		}
+        if ($Credential.Username -ne $WebSession.Credentials.Username) {
+            Write-Verbose "Using credentials from WebSession"
+            $Credential = New-Object System.Management.Automation.PSCredential "$($WebSession.Credentials.UserName)@$($WebSession.Credentials.Domain)", $WebSession.Credentials.SecurePassword 
+        }
         $ReportPortalUri = Get-RsPortalUriHelper -WebSession $WebSession
         $dataSourcesUri = $ReportPortalUri + "api/$RestApiVersion/{0}(Path='{1}')/DataSources"
     }

--- a/ReportingServicesTools/Functions/CatalogItems/Rest/Set-RsRestItemDataSource.ps1
+++ b/ReportingServicesTools/Functions/CatalogItems/Rest/Set-RsRestItemDataSource.ps1
@@ -138,7 +138,7 @@ function Set-RsRestItemDataSource
     Begin
     {
         $WebSession = New-RsRestSessionHelper -BoundParameters $PSBoundParameters
-        if ($Credential.Username -ne $WebSession.Credentials.Username) {
+        if ($null -ne $WebSession.Credentials -and $null -eq $Credential) {
             Write-Verbose "Using credentials from WebSession"
             $Credential = New-Object System.Management.Automation.PSCredential "$($WebSession.Credentials.UserName)@$($WebSession.Credentials.Domain)", $WebSession.Credentials.SecurePassword 
         }

--- a/ReportingServicesTools/Functions/CatalogItems/Rest/Start-RsRestCacheRefreshPlan.ps1
+++ b/ReportingServicesTools/Functions/CatalogItems/Rest/Start-RsRestCacheRefreshPlan.ps1
@@ -95,10 +95,10 @@ function Start-RsRestCacheRefreshPlan
     Begin
     {
         $WebSession = New-RsRestSessionHelper -BoundParameters $PSBoundParameters
-		if ($Credential.Username -ne $WebSession.Credentials.Username) {
-			Write-Verbose "Using credentials from WebSession"
-			$Credential = New-Object System.Management.Automation.PSCredential "$($WebSession.Credentials.UserName)@$($WebSession.Credentials.Domain)", $WebSession.Credentials.SecurePassword 
-		}
+        if ($Credential.Username -ne $WebSession.Credentials.Username) {
+            Write-Verbose "Using credentials from WebSession"
+            $Credential = New-Object System.Management.Automation.PSCredential "$($WebSession.Credentials.UserName)@$($WebSession.Credentials.Domain)", $WebSession.Credentials.SecurePassword 
+        }
         $ReportPortalUri = Get-RsPortalUriHelper -WebSession $WebSession
         $CacheRefreshPlansUri = $ReportPortalUri + "api/$RestApiVersion/CacheRefreshPlans({0})/Model.Execute"
     }

--- a/ReportingServicesTools/Functions/CatalogItems/Rest/Start-RsRestCacheRefreshPlan.ps1
+++ b/ReportingServicesTools/Functions/CatalogItems/Rest/Start-RsRestCacheRefreshPlan.ps1
@@ -95,7 +95,7 @@ function Start-RsRestCacheRefreshPlan
     Begin
     {
         $WebSession = New-RsRestSessionHelper -BoundParameters $PSBoundParameters
-        if ($Credential.Username -ne $WebSession.Credentials.Username) {
+        if ($null -ne $WebSession.Credentials -and $null -eq $Credential) {
             Write-Verbose "Using credentials from WebSession"
             $Credential = New-Object System.Management.Automation.PSCredential "$($WebSession.Credentials.UserName)@$($WebSession.Credentials.Domain)", $WebSession.Credentials.SecurePassword 
         }

--- a/ReportingServicesTools/Functions/CatalogItems/Rest/Start-RsRestCacheRefreshPlan.ps1
+++ b/ReportingServicesTools/Functions/CatalogItems/Rest/Start-RsRestCacheRefreshPlan.ps1
@@ -97,7 +97,7 @@ function Start-RsRestCacheRefreshPlan
         $WebSession = New-RsRestSessionHelper -BoundParameters $PSBoundParameters
 		if ($Credential.Username -ne $WebSession.Credentials.Username) {
 			Write-Verbose "Using credentials from WebSession"
-			$Credential = New-Object System.Management.Automation.PSCredential "$($WebSession.Credentials.UserName)@$($WebSession.Credentials.Domain)", (ConvertTo-SecureString $WebSession.Credentials.Password -AsPlainText -Force)
+			$Credential = New-Object System.Management.Automation.PSCredential "$($WebSession.Credentials.UserName)@$($WebSession.Credentials.Domain)", $WebSession.Credentials.SecurePassword 
 		}
         $ReportPortalUri = Get-RsPortalUriHelper -WebSession $WebSession
         $CacheRefreshPlansUri = $ReportPortalUri + "api/$RestApiVersion/CacheRefreshPlans({0})/Model.Execute"

--- a/ReportingServicesTools/Functions/CatalogItems/Rest/Start-RsRestCacheRefreshPlan.ps1
+++ b/ReportingServicesTools/Functions/CatalogItems/Rest/Start-RsRestCacheRefreshPlan.ps1
@@ -95,6 +95,10 @@ function Start-RsRestCacheRefreshPlan
     Begin
     {
         $WebSession = New-RsRestSessionHelper -BoundParameters $PSBoundParameters
+		if ($Credential.Username -ne $WebSession.Credentials.Username) {
+			Write-Verbose "Using credentials from WebSession"
+			$Credential = New-Object System.Management.Automation.PSCredential "$($WebSession.Credentials.UserName)@$($WebSession.Credentials.Domain)", (ConvertTo-SecureString $WebSession.Credentials.Password -AsPlainText -Force)
+		}
         $ReportPortalUri = Get-RsPortalUriHelper -WebSession $WebSession
         $CacheRefreshPlansUri = $ReportPortalUri + "api/$RestApiVersion/CacheRefreshPlans({0})/Model.Execute"
     }

--- a/ReportingServicesTools/Functions/CatalogItems/Rest/Test-RsRestItemDataSource.ps1
+++ b/ReportingServicesTools/Functions/CatalogItems/Rest/Test-RsRestItemDataSource.ps1
@@ -73,7 +73,7 @@ function Test-RsRestItemDataSource
         $WebSession = New-RsRestSessionHelper -BoundParameters $PSBoundParameters
 		if ($Credential.Username -ne $WebSession.Credentials.Username) {
 			Write-Verbose "Using credentials from WebSession"
-			$Credential = New-Object System.Management.Automation.PSCredential "$($WebSession.Credentials.UserName)@$($WebSession.Credentials.Domain)", (ConvertTo-SecureString $WebSession.Credentials.Password -AsPlainText -Force)
+			$Credential = New-Object System.Management.Automation.PSCredential "$($WebSession.Credentials.UserName)@$($WebSession.Credentials.Domain)", $WebSession.Credentials.SecurePassword 
 		}
         $ReportPortalUri = Get-RsPortalUriHelper -WebSession $WebSession
     }

--- a/ReportingServicesTools/Functions/CatalogItems/Rest/Test-RsRestItemDataSource.ps1
+++ b/ReportingServicesTools/Functions/CatalogItems/Rest/Test-RsRestItemDataSource.ps1
@@ -71,6 +71,10 @@ function Test-RsRestItemDataSource
     Begin
     {
         $WebSession = New-RsRestSessionHelper -BoundParameters $PSBoundParameters
+		if ($Credential.Username -ne $WebSession.Credentials.Username) {
+			Write-Verbose "Using credentials from WebSession"
+			$Credential = New-Object System.Management.Automation.PSCredential "$($WebSession.Credentials.UserName)@$($WebSession.Credentials.Domain)", (ConvertTo-SecureString $WebSession.Credentials.Password -AsPlainText -Force)
+		}
         $ReportPortalUri = Get-RsPortalUriHelper -WebSession $WebSession
     }
     Process

--- a/ReportingServicesTools/Functions/CatalogItems/Rest/Test-RsRestItemDataSource.ps1
+++ b/ReportingServicesTools/Functions/CatalogItems/Rest/Test-RsRestItemDataSource.ps1
@@ -71,7 +71,7 @@ function Test-RsRestItemDataSource
     Begin
     {
         $WebSession = New-RsRestSessionHelper -BoundParameters $PSBoundParameters
-        if ($Credential.Username -ne $WebSession.Credentials.Username) {
+        if ($null -ne $WebSession.Credentials -and $null -eq $Credential) {
             Write-Verbose "Using credentials from WebSession"
             $Credential = New-Object System.Management.Automation.PSCredential "$($WebSession.Credentials.UserName)@$($WebSession.Credentials.Domain)", $WebSession.Credentials.SecurePassword 
         }

--- a/ReportingServicesTools/Functions/CatalogItems/Rest/Test-RsRestItemDataSource.ps1
+++ b/ReportingServicesTools/Functions/CatalogItems/Rest/Test-RsRestItemDataSource.ps1
@@ -71,10 +71,10 @@ function Test-RsRestItemDataSource
     Begin
     {
         $WebSession = New-RsRestSessionHelper -BoundParameters $PSBoundParameters
-		if ($Credential.Username -ne $WebSession.Credentials.Username) {
-			Write-Verbose "Using credentials from WebSession"
-			$Credential = New-Object System.Management.Automation.PSCredential "$($WebSession.Credentials.UserName)@$($WebSession.Credentials.Domain)", $WebSession.Credentials.SecurePassword 
-		}
+        if ($Credential.Username -ne $WebSession.Credentials.Username) {
+            Write-Verbose "Using credentials from WebSession"
+            $Credential = New-Object System.Management.Automation.PSCredential "$($WebSession.Credentials.UserName)@$($WebSession.Credentials.Domain)", $WebSession.Credentials.SecurePassword 
+        }
         $ReportPortalUri = Get-RsPortalUriHelper -WebSession $WebSession
     }
     Process

--- a/ReportingServicesTools/Functions/CatalogItems/Rest/Write-RsRestCatalogItem.ps1
+++ b/ReportingServicesTools/Functions/CatalogItems/Rest/Write-RsRestCatalogItem.ps1
@@ -115,7 +115,7 @@ function Write-RsRestCatalogItem
         $WebSession = New-RsRestSessionHelper -BoundParameters $PSBoundParameters
 		if ($Credential.Username -ne $WebSession.Credentials.Username) {
 			Write-Verbose "Using credentials from WebSession"
-			$Credential = New-Object System.Management.Automation.PSCredential "$($WebSession.Credentials.UserName)@$($WebSession.Credentials.Domain)", (ConvertTo-SecureString $WebSession.Credentials.Password -AsPlainText -Force)
+			$Credential = New-Object System.Management.Automation.PSCredential "$($WebSession.Credentials.UserName)@$($WebSession.Credentials.Domain)", $WebSession.Credentials.SecurePassword 
 		}
         $ReportPortalUri = Get-RsPortalUriHelper -WebSession $WebSession
         $catalogItemsUri = $ReportPortalUri + "api/$RestApiVersion/CatalogItems"

--- a/ReportingServicesTools/Functions/CatalogItems/Rest/Write-RsRestCatalogItem.ps1
+++ b/ReportingServicesTools/Functions/CatalogItems/Rest/Write-RsRestCatalogItem.ps1
@@ -113,10 +113,10 @@ function Write-RsRestCatalogItem
     Begin
     {
         $WebSession = New-RsRestSessionHelper -BoundParameters $PSBoundParameters
-		if ($Credential.Username -ne $WebSession.Credentials.Username) {
-			Write-Verbose "Using credentials from WebSession"
-			$Credential = New-Object System.Management.Automation.PSCredential "$($WebSession.Credentials.UserName)@$($WebSession.Credentials.Domain)", $WebSession.Credentials.SecurePassword 
-		}
+        if ($Credential.Username -ne $WebSession.Credentials.Username) {
+            Write-Verbose "Using credentials from WebSession"
+            $Credential = New-Object System.Management.Automation.PSCredential "$($WebSession.Credentials.UserName)@$($WebSession.Credentials.Domain)", $WebSession.Credentials.SecurePassword 
+        }
         $ReportPortalUri = Get-RsPortalUriHelper -WebSession $WebSession
         $catalogItemsUri = $ReportPortalUri + "api/$RestApiVersion/CatalogItems"
         if ($RestApiVersion -eq "v1.0")

--- a/ReportingServicesTools/Functions/CatalogItems/Rest/Write-RsRestCatalogItem.ps1
+++ b/ReportingServicesTools/Functions/CatalogItems/Rest/Write-RsRestCatalogItem.ps1
@@ -113,6 +113,10 @@ function Write-RsRestCatalogItem
     Begin
     {
         $WebSession = New-RsRestSessionHelper -BoundParameters $PSBoundParameters
+		if ($Credential.Username -ne $WebSession.Credentials.Username) {
+			Write-Verbose "Using credentials from WebSession"
+			$Credential = New-Object System.Management.Automation.PSCredential "$($WebSession.Credentials.UserName)@$($WebSession.Credentials.Domain)", (ConvertTo-SecureString $WebSession.Credentials.Password -AsPlainText -Force)
+		}
         $ReportPortalUri = Get-RsPortalUriHelper -WebSession $WebSession
         $catalogItemsUri = $ReportPortalUri + "api/$RestApiVersion/CatalogItems"
         if ($RestApiVersion -eq "v1.0")

--- a/ReportingServicesTools/Functions/CatalogItems/Rest/Write-RsRestCatalogItem.ps1
+++ b/ReportingServicesTools/Functions/CatalogItems/Rest/Write-RsRestCatalogItem.ps1
@@ -113,7 +113,7 @@ function Write-RsRestCatalogItem
     Begin
     {
         $WebSession = New-RsRestSessionHelper -BoundParameters $PSBoundParameters
-        if ($Credential.Username -ne $WebSession.Credentials.Username) {
+        if ($null -ne $WebSession.Credentials -and $null -eq $Credential) {
             Write-Verbose "Using credentials from WebSession"
             $Credential = New-Object System.Management.Automation.PSCredential "$($WebSession.Credentials.UserName)@$($WebSession.Credentials.Domain)", $WebSession.Credentials.SecurePassword 
         }

--- a/ReportingServicesTools/Functions/CatalogItems/Rest/Write-RsRestFolderContent.ps1
+++ b/ReportingServicesTools/Functions/CatalogItems/Rest/Write-RsRestFolderContent.ps1
@@ -99,7 +99,7 @@ function Write-RsRestFolderContent
         $WebSession = New-RsRestSessionHelper -BoundParameters $PSBoundParameters
 		if ($Credential.Username -ne $WebSession.Credentials.Username) {
 			Write-Verbose "Using credentials from WebSession"
-			$Credential = New-Object System.Management.Automation.PSCredential "$($WebSession.Credentials.UserName)@$($WebSession.Credentials.Domain)", (ConvertTo-SecureString $WebSession.Credentials.Password -AsPlainText -Force)
+			$Credential = New-Object System.Management.Automation.PSCredential "$($WebSession.Credentials.UserName)@$($WebSession.Credentials.Domain)", $WebSession.Credentials.SecurePassword 
 		}
         $ReportPortalUri = Get-RsPortalUriHelper -WebSession $WebSession
         $catalogItemsUri = $ReportPortalUri + "api/$RestApiVersion/CatalogItems"

--- a/ReportingServicesTools/Functions/CatalogItems/Rest/Write-RsRestFolderContent.ps1
+++ b/ReportingServicesTools/Functions/CatalogItems/Rest/Write-RsRestFolderContent.ps1
@@ -97,6 +97,10 @@ function Write-RsRestFolderContent
     Begin
     {
         $WebSession = New-RsRestSessionHelper -BoundParameters $PSBoundParameters
+		if ($Credential.Username -ne $WebSession.Credentials.Username) {
+			Write-Verbose "Using credentials from WebSession"
+			$Credential = New-Object System.Management.Automation.PSCredential "$($WebSession.Credentials.UserName)@$($WebSession.Credentials.Domain)", (ConvertTo-SecureString $WebSession.Credentials.Password -AsPlainText -Force)
+		}
         $ReportPortalUri = Get-RsPortalUriHelper -WebSession $WebSession
         $catalogItemsUri = $ReportPortalUri + "api/$RestApiVersion/CatalogItems"
         $folderUri = $ReportPortalUri + "api/$RestApiVersion/Folders(Path='{0}')"

--- a/ReportingServicesTools/Functions/CatalogItems/Rest/Write-RsRestFolderContent.ps1
+++ b/ReportingServicesTools/Functions/CatalogItems/Rest/Write-RsRestFolderContent.ps1
@@ -97,7 +97,7 @@ function Write-RsRestFolderContent
     Begin
     {
         $WebSession = New-RsRestSessionHelper -BoundParameters $PSBoundParameters
-        if ($Credential.Username -ne $WebSession.Credentials.Username) {
+        if ($null -ne $WebSession.Credentials -and $null -eq $Credential) {
             Write-Verbose "Using credentials from WebSession"
             $Credential = New-Object System.Management.Automation.PSCredential "$($WebSession.Credentials.UserName)@$($WebSession.Credentials.Domain)", $WebSession.Credentials.SecurePassword 
         }

--- a/ReportingServicesTools/Functions/CatalogItems/Rest/Write-RsRestFolderContent.ps1
+++ b/ReportingServicesTools/Functions/CatalogItems/Rest/Write-RsRestFolderContent.ps1
@@ -97,10 +97,10 @@ function Write-RsRestFolderContent
     Begin
     {
         $WebSession = New-RsRestSessionHelper -BoundParameters $PSBoundParameters
-		if ($Credential.Username -ne $WebSession.Credentials.Username) {
-			Write-Verbose "Using credentials from WebSession"
-			$Credential = New-Object System.Management.Automation.PSCredential "$($WebSession.Credentials.UserName)@$($WebSession.Credentials.Domain)", $WebSession.Credentials.SecurePassword 
-		}
+        if ($Credential.Username -ne $WebSession.Credentials.Username) {
+            Write-Verbose "Using credentials from WebSession"
+            $Credential = New-Object System.Management.Automation.PSCredential "$($WebSession.Credentials.UserName)@$($WebSession.Credentials.Domain)", $WebSession.Credentials.SecurePassword 
+        }
         $ReportPortalUri = Get-RsPortalUriHelper -WebSession $WebSession
         $catalogItemsUri = $ReportPortalUri + "api/$RestApiVersion/CatalogItems"
         $folderUri = $ReportPortalUri + "api/$RestApiVersion/Folders(Path='{0}')"

--- a/ReportingServicesTools/Functions/Security/Rest/Get-RsRestItemAccessPolicy.ps1
+++ b/ReportingServicesTools/Functions/Security/Rest/Get-RsRestItemAccessPolicy.ps1
@@ -81,6 +81,10 @@ function Get-RsRestItemAccessPolicy
     Begin
     {
         $WebSession = New-RsRestSessionHelper -BoundParameters $PSBoundParameters
+		if ($Credential.Username -ne $WebSession.Credentials.Username) {
+			Write-Verbose "Using credentials from WebSession"
+			$Credential = New-Object System.Management.Automation.PSCredential "$($WebSession.Credentials.UserName)@$($WebSession.Credentials.Domain)", (ConvertTo-SecureString $WebSession.Credentials.Password -AsPlainText -Force)
+		}
         $ReportPortalUri = Get-RsPortalUriHelper -WebSession $WebSession
         $PolicyUri = $ReportPortalUri + "api/$RestApiVersion/CatalogItems({0})/Policies"
     }

--- a/ReportingServicesTools/Functions/Security/Rest/Get-RsRestItemAccessPolicy.ps1
+++ b/ReportingServicesTools/Functions/Security/Rest/Get-RsRestItemAccessPolicy.ps1
@@ -83,7 +83,7 @@ function Get-RsRestItemAccessPolicy
         $WebSession = New-RsRestSessionHelper -BoundParameters $PSBoundParameters
 		if ($Credential.Username -ne $WebSession.Credentials.Username) {
 			Write-Verbose "Using credentials from WebSession"
-			$Credential = New-Object System.Management.Automation.PSCredential "$($WebSession.Credentials.UserName)@$($WebSession.Credentials.Domain)", (ConvertTo-SecureString $WebSession.Credentials.Password -AsPlainText -Force)
+			$Credential = New-Object System.Management.Automation.PSCredential "$($WebSession.Credentials.UserName)@$($WebSession.Credentials.Domain)", $WebSession.Credentials.SecurePassword 
 		}
         $ReportPortalUri = Get-RsPortalUriHelper -WebSession $WebSession
         $PolicyUri = $ReportPortalUri + "api/$RestApiVersion/CatalogItems({0})/Policies"

--- a/ReportingServicesTools/Functions/Security/Rest/Get-RsRestItemAccessPolicy.ps1
+++ b/ReportingServicesTools/Functions/Security/Rest/Get-RsRestItemAccessPolicy.ps1
@@ -81,10 +81,10 @@ function Get-RsRestItemAccessPolicy
     Begin
     {
         $WebSession = New-RsRestSessionHelper -BoundParameters $PSBoundParameters
-		if ($Credential.Username -ne $WebSession.Credentials.Username) {
-			Write-Verbose "Using credentials from WebSession"
-			$Credential = New-Object System.Management.Automation.PSCredential "$($WebSession.Credentials.UserName)@$($WebSession.Credentials.Domain)", $WebSession.Credentials.SecurePassword 
-		}
+        if ($Credential.Username -ne $WebSession.Credentials.Username) {
+            Write-Verbose "Using credentials from WebSession"
+            $Credential = New-Object System.Management.Automation.PSCredential "$($WebSession.Credentials.UserName)@$($WebSession.Credentials.Domain)", $WebSession.Credentials.SecurePassword 
+        }
         $ReportPortalUri = Get-RsPortalUriHelper -WebSession $WebSession
         $PolicyUri = $ReportPortalUri + "api/$RestApiVersion/CatalogItems({0})/Policies"
     }

--- a/ReportingServicesTools/Functions/Security/Rest/Get-RsRestItemAccessPolicy.ps1
+++ b/ReportingServicesTools/Functions/Security/Rest/Get-RsRestItemAccessPolicy.ps1
@@ -81,7 +81,7 @@ function Get-RsRestItemAccessPolicy
     Begin
     {
         $WebSession = New-RsRestSessionHelper -BoundParameters $PSBoundParameters
-        if ($Credential.Username -ne $WebSession.Credentials.Username) {
+        if ($null -ne $WebSession.Credentials -and $null -eq $Credential) {
             Write-Verbose "Using credentials from WebSession"
             $Credential = New-Object System.Management.Automation.PSCredential "$($WebSession.Credentials.UserName)@$($WebSession.Credentials.Domain)", $WebSession.Credentials.SecurePassword 
         }

--- a/ReportingServicesTools/Functions/Security/Rest/Grant-RsRestItemAccessPolicy.ps1
+++ b/ReportingServicesTools/Functions/Security/Rest/Grant-RsRestItemAccessPolicy.ps1
@@ -91,7 +91,7 @@ function Grant-RsRestItemAccessPolicy
     Begin
     {
         $WebSession = New-RsRestSessionHelper -BoundParameters $PSBoundParameters
-        if ($Credential.Username -ne $WebSession.Credentials.Username) {
+        if ($null -ne $WebSession.Credentials -and $null -eq $Credential) {
             Write-Verbose "Using credentials from WebSession"
             $Credential = New-Object System.Management.Automation.PSCredential "$($WebSession.Credentials.UserName)@$($WebSession.Credentials.Domain)", $WebSession.Credentials.SecurePassword 
         }

--- a/ReportingServicesTools/Functions/Security/Rest/Grant-RsRestItemAccessPolicy.ps1
+++ b/ReportingServicesTools/Functions/Security/Rest/Grant-RsRestItemAccessPolicy.ps1
@@ -91,6 +91,10 @@ function Grant-RsRestItemAccessPolicy
     Begin
     {
         $WebSession = New-RsRestSessionHelper -BoundParameters $PSBoundParameters
+		if ($Credential.Username -ne $WebSession.Credentials.Username) {
+			Write-Verbose "Using credentials from WebSession"
+			$Credential = New-Object System.Management.Automation.PSCredential "$($WebSession.Credentials.UserName)@$($WebSession.Credentials.Domain)", (ConvertTo-SecureString $WebSession.Credentials.Password -AsPlainText -Force)
+		}
         $ReportPortalUri = Get-RsPortalUriHelper -WebSession $WebSession
     }
     Process

--- a/ReportingServicesTools/Functions/Security/Rest/Grant-RsRestItemAccessPolicy.ps1
+++ b/ReportingServicesTools/Functions/Security/Rest/Grant-RsRestItemAccessPolicy.ps1
@@ -93,7 +93,7 @@ function Grant-RsRestItemAccessPolicy
         $WebSession = New-RsRestSessionHelper -BoundParameters $PSBoundParameters
 		if ($Credential.Username -ne $WebSession.Credentials.Username) {
 			Write-Verbose "Using credentials from WebSession"
-			$Credential = New-Object System.Management.Automation.PSCredential "$($WebSession.Credentials.UserName)@$($WebSession.Credentials.Domain)", (ConvertTo-SecureString $WebSession.Credentials.Password -AsPlainText -Force)
+			$Credential = New-Object System.Management.Automation.PSCredential "$($WebSession.Credentials.UserName)@$($WebSession.Credentials.Domain)", $WebSession.Credentials.SecurePassword 
 		}
         $ReportPortalUri = Get-RsPortalUriHelper -WebSession $WebSession
     }

--- a/ReportingServicesTools/Functions/Security/Rest/Grant-RsRestItemAccessPolicy.ps1
+++ b/ReportingServicesTools/Functions/Security/Rest/Grant-RsRestItemAccessPolicy.ps1
@@ -91,10 +91,10 @@ function Grant-RsRestItemAccessPolicy
     Begin
     {
         $WebSession = New-RsRestSessionHelper -BoundParameters $PSBoundParameters
-		if ($Credential.Username -ne $WebSession.Credentials.Username) {
-			Write-Verbose "Using credentials from WebSession"
-			$Credential = New-Object System.Management.Automation.PSCredential "$($WebSession.Credentials.UserName)@$($WebSession.Credentials.Domain)", $WebSession.Credentials.SecurePassword 
-		}
+        if ($Credential.Username -ne $WebSession.Credentials.Username) {
+            Write-Verbose "Using credentials from WebSession"
+            $Credential = New-Object System.Management.Automation.PSCredential "$($WebSession.Credentials.UserName)@$($WebSession.Credentials.Domain)", $WebSession.Credentials.SecurePassword 
+        }
         $ReportPortalUri = Get-RsPortalUriHelper -WebSession $WebSession
     }
     Process

--- a/ReportingServicesTools/Functions/Security/Rest/Revoke-RsRestItemAccessPolicy.ps1
+++ b/ReportingServicesTools/Functions/Security/Rest/Revoke-RsRestItemAccessPolicy.ps1
@@ -76,7 +76,7 @@ function Revoke-RsRestItemAccessPolicy
     Begin
     {
         $WebSession = New-RsRestSessionHelper -BoundParameters $PSBoundParameters
-        if ($Credential.Username -ne $WebSession.Credentials.Username) {
+        if ($null -ne $WebSession.Credentials -and $null -eq $Credential) {
             Write-Verbose "Using credentials from WebSession"
             $Credential = New-Object System.Management.Automation.PSCredential "$($WebSession.Credentials.UserName)@$($WebSession.Credentials.Domain)", $WebSession.Credentials.SecurePassword 
         }

--- a/ReportingServicesTools/Functions/Security/Rest/Revoke-RsRestItemAccessPolicy.ps1
+++ b/ReportingServicesTools/Functions/Security/Rest/Revoke-RsRestItemAccessPolicy.ps1
@@ -76,6 +76,10 @@ function Revoke-RsRestItemAccessPolicy
     Begin
     {
         $WebSession = New-RsRestSessionHelper -BoundParameters $PSBoundParameters
+		if ($Credential.Username -ne $WebSession.Credentials.Username) {
+			Write-Verbose "Using credentials from WebSession"
+			$Credential = New-Object System.Management.Automation.PSCredential "$($WebSession.Credentials.UserName)@$($WebSession.Credentials.Domain)", (ConvertTo-SecureString $WebSession.Credentials.Password -AsPlainText -Force)
+		}
         $ReportPortalUri = Get-RsPortalUriHelper -WebSession $WebSession
     }
     Process

--- a/ReportingServicesTools/Functions/Security/Rest/Revoke-RsRestItemAccessPolicy.ps1
+++ b/ReportingServicesTools/Functions/Security/Rest/Revoke-RsRestItemAccessPolicy.ps1
@@ -76,10 +76,10 @@ function Revoke-RsRestItemAccessPolicy
     Begin
     {
         $WebSession = New-RsRestSessionHelper -BoundParameters $PSBoundParameters
-		if ($Credential.Username -ne $WebSession.Credentials.Username) {
-			Write-Verbose "Using credentials from WebSession"
-			$Credential = New-Object System.Management.Automation.PSCredential "$($WebSession.Credentials.UserName)@$($WebSession.Credentials.Domain)", $WebSession.Credentials.SecurePassword 
-		}
+        if ($Credential.Username -ne $WebSession.Credentials.Username) {
+            Write-Verbose "Using credentials from WebSession"
+            $Credential = New-Object System.Management.Automation.PSCredential "$($WebSession.Credentials.UserName)@$($WebSession.Credentials.Domain)", $WebSession.Credentials.SecurePassword 
+        }
         $ReportPortalUri = Get-RsPortalUriHelper -WebSession $WebSession
     }
     Process

--- a/ReportingServicesTools/Functions/Security/Rest/Revoke-RsRestItemAccessPolicy.ps1
+++ b/ReportingServicesTools/Functions/Security/Rest/Revoke-RsRestItemAccessPolicy.ps1
@@ -78,7 +78,7 @@ function Revoke-RsRestItemAccessPolicy
         $WebSession = New-RsRestSessionHelper -BoundParameters $PSBoundParameters
 		if ($Credential.Username -ne $WebSession.Credentials.Username) {
 			Write-Verbose "Using credentials from WebSession"
-			$Credential = New-Object System.Management.Automation.PSCredential "$($WebSession.Credentials.UserName)@$($WebSession.Credentials.Domain)", (ConvertTo-SecureString $WebSession.Credentials.Password -AsPlainText -Force)
+			$Credential = New-Object System.Management.Automation.PSCredential "$($WebSession.Credentials.UserName)@$($WebSession.Credentials.Domain)", $WebSession.Credentials.SecurePassword 
 		}
         $ReportPortalUri = Get-RsPortalUriHelper -WebSession $WebSession
     }


### PR DESCRIPTION
Fixes #377.

Changes proposed in this pull request:
 - If passing a WebSession and the Credentials are not supplied, the code checks if the credentials were originally set in New-RsRestSession call and retrieves those for use in the function

How to test this code:
 - I have tested rest code using web sessions with and without passing the credentials in the individual calls
 - I have also did some basic testing when using -DefaultCredentials parameter and it all seems to work as expected.
 
Has been tested on (remove any that don't apply):
 - Powershell 5 and above
 - SQL Server 2016 and above
