### PR TITLE
Fixed issue with Resolve-Path breaking UNC keypaths.

### DIFF
--- a/ReportingServicesTools/Functions/Admin/Restore-RsEncryptionKey.ps1
+++ b/ReportingServicesTools/Functions/Admin/Restore-RsEncryptionKey.ps1
@@ -74,9 +74,8 @@ function Restore-RSEncryptionKey
     if ($PSCmdlet.ShouldProcess((Get-ShouldProcessTargetWmi -BoundParameters $PSBoundParameters), "Restore encryptionkey from file $KeyPath"))
     {
         $rsWmiObject = New-RsConfigurationSettingObjectHelper -BoundParameters $PSBoundParameters
-
        
-        $KeyPath = Join-Path -Path (Resolve-Path -Path (Split-Path -Parent $KeyPath)).ProviderPath -ChildPath (Split-Path -Leaf $KeyPath)
+        $KeyPath = (Resolve-Path $KeyPath).ProviderPath
 
         $reportServerService = 'ReportServer'
 


### PR DESCRIPTION
Fixes https://github.com/microsoft/ReportingServicesTools/issues/384 .

Changes proposed in this pull request:

Changes Resolve-Path to examine the path as a Parent and Child instead of as a single unit to avoid damaging the proper UNC path.
How to test this code:
Restore-RSEncryptionKey -ReportServerInstance "Instance" -Password "Password" -KeyPath "\domain\share\folder\keyfile.snk"
(Testing outside the module requires functions in ShouldProcess.ps1 and ConnectionObjectRequests.ps1)

Has been tested on (remove any that don't apply):

PSVersion 5.1.17763.2931
Windows Server 2019 Datacenter
SQL Server 2016