### PR TITLE
Exclude Linked Reports

### DIFF
--- a/ReportingServicesTools/Functions/CatalogItems/Rest/Out-RsRestCatalogItemId.ps1
+++ b/ReportingServicesTools/Functions/CatalogItems/Rest/Out-RsRestCatalogItemId.ps1
@@ -83,6 +83,13 @@ function Out-RsRestCatalogItemId
 
     Process
     {
+        #exlude Linked Reports
+        if ($RsItemInfo.Type -eq 'LinkedReport')
+        {
+            Write-Verbose "$($RsItemInfo.Path) is a LinkedReport and is ignored."
+            return
+        }
+
         if ($RsItemInfo.Type -ne 'MobileReport')
         {
             $itemId = $RsItemInfo.Id


### PR DESCRIPTION
Exclude Linked Reports from being downloaded by the function Out-RsRestCatalogItemId because it cannot download them anyway. It was causing bugs when wanting to download content from Report Server (type was not invalid).

Changes proposed in this pull request:
- Exclude Linked Reports from the list of downloadable items of Report Server

How to test this code:

- Create a Linked Report in your Report Server and use this function to download the content of Report Server. It will ignore the Linked Report and download other reports as usual.

Has been tested on (remove any that don't apply):
- Powershell 5.1
- Windows 10
