### PR TITLE
Update Publish-RsProject.ps1 - Change in the Documentation example section to have the correct Parameter name.

### DIFF
--- a/ReportingServicesTools/Functions/CatalogItems/Publish-RsProject.ps1
+++ b/ReportingServicesTools/Functions/CatalogItems/Publish-RsProject.ps1
@@ -11,7 +11,7 @@ function Publish-RsProject
             Specify the location of the SSRS project file whose deployment profiles should be fetched.
 
         .EXAMPLE
-            Get-RsDeploymentConfig -ProjectFile 'C:\Users\Aaron\source\repos\Finance\Financial Reports\SSRS_FR\SSRS_FR.rptproj' |
+            Get-RsDeploymentConfig -RsProjectFile 'C:\Users\Aaron\source\repos\Finance\Financial Reports\SSRS_FR\SSRS_FR.rptproj' |
             Add-Member -PassThru -MemberType NoteProperty -Name ReportPortal -Value 'http://localhost/PBIRSportal/' |
             Publish-RsProject
 


### PR DESCRIPTION
Changed in the documentation path of .EXAMPLE where the input parameter name should be -RsProjectFile instead of -RsProjectFile.

Fixes # .

Changes proposed in this pull request:
 - Fix in the documentation to rename the parameter to Get-RsDeploymentConfig from -ProjectFile to -RsProjectFile.

How to test this code:
 - There is only change to documentation example which is commented and no changes done in the code. To test this we should be running only Publish-RsProject.ps1 to make sure it does not impact on the existing functionality. 

Has been tested on (remove any that don't apply):
 - Powershell 3 and above
 - Windows 7 and above
 - SQL Server 2012 and above
