### PR TITLE
Updated Set-RsDatabase and Set-RsDatabaseCredentials scripts to support new parameters of Invoke-Sqlcmd.

### DIFF
--- a/ReportingServicesTools/Functions/Admin/Set-RsDatabase.ps1
+++ b/ReportingServicesTools/Functions/Admin/Set-RsDatabase.ps1
@@ -41,7 +41,7 @@ function Set-RsDatabase
         .PARAMETER Encrypt
             Specify the encryption type to use when connecting to SQL Server.
             Accepted values: Mandatory, Optional, Strict.
-            If supported, but not specified, the default value is Mandatory.
+            IMPORTANT: If supported by the Invoke-Sqlcmd cmdlet version in use, but not specified, the default value is Mandatory.
             Using this parameter requires PowerShell SQLServer module version 22 or higher.
 
         .PARAMETER TrustServerCertificate

--- a/ReportingServicesTools/Functions/Admin/Set-RsDatabase.ps1
+++ b/ReportingServicesTools/Functions/Admin/Set-RsDatabase.ps1
@@ -210,6 +210,37 @@ function Set-RsDatabase
         }
         #endregion Validating admin authentication and normalizing credentials
 
+        #region Composing general parameters for Invoke-Sqlcmd cmdlet
+        $generalParameters = @{
+            ServerInstance = $DatabaseServerName
+            QueryTimeout = $QueryTimeout
+            ErrorAction = "Stop"
+        }
+
+        if ($isSQLAdminAccount)
+        {
+            $generalParameters.add("Username", $adminUsername)
+            $generalParameters.add("Password", $adminPassword)
+        }
+
+        if ($containsSQLServerV22Parameters)
+        {
+            if ($PSBoundParameters.ContainsKey("Encrypt"))
+            {
+                $generalParameters.add("Encrypt", $Encrypt)
+            }
+
+            if ($TrustServerCertificate)
+            {
+                $generalParameters.add("TrustServerCertificate", $true)
+            }
+
+            if ($PSBoundParameters.ContainsKey("HostNameInCertificate"))
+            {
+                $generalParameters.add("HostNameInCertificate", $HostNameInCertificate)
+            }
+        }
+        #endregion Composing general parameters for Invoke-Sqlcmd cmdlet
 
         #region Create Database if necessary
         if (-not $IsExistingDatabase)
@@ -234,44 +265,13 @@ function Set-RsDatabase
             Write-Verbose "Executing database creation script..."
             try
             {
-                $parameters = @{
-                    ServerInstance = $DatabaseServerName
-                    Query = $SQLScript
-                    QueryTimeout = $QueryTimeout
-                    ErrorAction = "Stop"
-                }
-
-                if ($isSQLAdminAccount)
-                {
-                    $parameters.add("Username", $adminUsername)
-                    $parameters.add("Password", $adminPassword)
-                }
-
-                if ($containsSQLServerV22Parameters)
-                {
-                    if ($PSBoundParameters.ContainsKey("Encrypt"))
-                    {
-                        $parameters.add("Encrypt", $Encrypt)
-                    }
-        
-                    if ($TrustServerCertificate)
-                    {
-                        $parameters.add("TrustServerCertificate", $true)
-                    }
-        
-                    if ($PSBoundParameters.ContainsKey("HostNameInCertificate"))
-                    {
-                        $parameters.add("HostNameInCertificate", $HostNameInCertificate)
-                    }
-                }
-
                 if ($supportSQLServerV22Parameters)
                 {
-                    SQLServer\Invoke-Sqlcmd @parameters
+                    SQLServer\Invoke-Sqlcmd @generalParameters -Query $SQLScript
                 }
                 else
                 {
-                    Invoke-Sqlcmd @parameters
+                    Invoke-Sqlcmd @generalParameters -Query $SQLScript
                 }
             }
             catch
@@ -303,44 +303,13 @@ function Set-RsDatabase
         Write-Verbose "Executing database rights script..."
         try
         {
-            $parameters = @{
-                ServerInstance = $DatabaseServerName
-                Query = $SQLScript
-                QueryTimeout = $QueryTimeout
-                ErrorAction = "Stop"
-            }
-
-            if ($isSQLAdminAccount)
-            {
-                $parameters.add("Username", $adminUsername)
-                $parameters.add("Password", $adminPassword)
-            }
-
-            if ($containsSQLServerV22Parameters)
-            {
-                if ($PSBoundParameters.ContainsKey("Encrypt"))
-                {
-                    $parameters.add("Encrypt", $Encrypt)
-                }
-    
-                if ($TrustServerCertificate)
-                {
-                    $parameters.add("TrustServerCertificate", $true)
-                }
-    
-                if ($PSBoundParameters.ContainsKey("HostNameInCertificate"))
-                {
-                    $parameters.add("HostNameInCertificate", $HostNameInCertificate)
-                }
-            }
-
             if ($supportSQLServerV22Parameters)
             {
-                SQLServer\Invoke-Sqlcmd @parameters
+                SQLServer\Invoke-Sqlcmd @generalParameters -Query $SQLScript
             }
             else
             {
-                Invoke-Sqlcmd @parameters
+                Invoke-Sqlcmd @generalParameters -Query $SQLScript
             }
         }
         catch


### PR DESCRIPTION
### Motivation:

`Set-RsDatabase` script started to result in failure with the following error:

> Executing database creation script... Failed!
> Invoke-Sqlcmd : A connection was successfully established with the server, but then an error occurred during the login
> process. (provider: SSL Provider, error: 0 - The certificate chain was issued by an authority that is not trusted.)

After investigation, I discovered that this behavior is a result of the recent update of SQL [Strict Connection Encryption](https://learn.microsoft.com/en-us/sql/relational-databases/security/networking/tds-8-and-tls-1-3?view=sql-server-ver16#strict-connection-encryption), which introduced some changes to the defaults of SQL connection encryption.

Since v22, `Invoke-Sqlcmd` cmdlet from PowerShell SqlServer module has three new parameters:

   - -Encrypt;
   - -TrustServerCertificate;
   - -HostNameInCertificate.
  
According to the documentation on [Invoke-Sqlcmd](https://learn.microsoft.com/en-us/powershell/module/sqlserver/invoke-sqlcmd) cmdlet, the default value for `-Encrypt` parameter is now `Mandatory`, which seems to be the reason of the connection failure, since currently no value for `-Encrypt` parameter is specified for `Invoke-Sqlcmd` invocation in `Set-RsDatabase` script.

Previously the encryption of the connection depended on `-EncryptConnection` switch of `Invoke-Sqlcmd` cmdlet, which was not specified in the script and is considered deprecated since v22 of SqlServer module.

So, basically, if the user has the SqlServer module v22 or higher installed, the `Set-RsDatabase`/`Set-RsDatabaseCredentials` script uses the recently updated version of `Invoke-Sqlcmd` cmdlet, which makes the connection Mandatory encrypted by default.

I consider the ability to specify the newly introduced parameters a required improvment for `Set-RsDatabase` and `Set-RsDatabaseCredentials` scripts functionality.

### Changes proposed in this pull request:

 - Added new parameters to `Set-RsDatabase` and `Set-RsDatabaseCredentials` scripts according to updated `Invoke-Sqlcmd` parameters:
   - -Encrypt;
   - -TrustServerCertificate;
   - -HostNameInCertificate.
   
- Refactored parameters specification for `Invoke-Sqlcmd` invocation.

- I also tried to ensure compatibility of the modified scripts with different versions of `Invoke-Sqlcmd` cmdlet, since it is present in SqlServer , PsSqlLegacy and SQLPS modules:
  - If user doesn't have SqlServer module v22 or higher installed and no recently introduced parameters were specified, the behavior of the scripts will not be affected by these changes and the connection will not be encrypted (as before);
  - If the user has SqlServer module v22 or higher installed, PowerShell will most likely use the latest version of `Invoke-Sqlcmd` cmdlet from this module, and user will have to specify the recently introduced parameters to prevent the default encryption of the connection (`-Encrypt=Optional` and `-TrustServerCertificate` is advised);
  - If no installed SqlServer module v22 or higher was found, but the recently introduced parameters were specified, the user will receive an error, suggesting them to install the SqlServer module v22 or higher required for these parameters support.

### How to test this code:
 - Import the updated module, as described in ReadMe ("Local testing and development");
 - Manually execute `Set-RsDatabase`/`Set-RsDatabaseCredentials` script in different environments (various versions of SqlServer and other modules installed/removed);
 - Ensure that scripts and parameters work as described.

### Has been tested on:
- PowerShell 5.1
- PowerShell modules:
  - SqlServer 21.1.18256
  - SqlServer 22.0.59
  - SQLPS 15.0
  - SQLPS 16.0
- SQL Server 2019
- SQL Server 2022
- Windows 11 Enterprise