### PR TITLE
Update broken link in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,7 +159,7 @@ Import-Module ReportingServicesTools -UseWindowsPowerShell
 ```
 ## Style Guidelines
 
-If you have any scripts you would like to share, we request you to please format your scripts according to the guidelines created by the team behind the DSC Resource Kit. (https://github.com/PowerShell/DscResources/blob/master/StyleGuidelines.md) and the PowerShell verbs https://msdn.microsoft.com/en-us/library/ms714428(v=vs.85).aspx
+If you have any scripts you would like to share, we request you to please format your scripts according to the guidelines created by the team behind the DSC Resource Kit. (https://github.com/PowerShell/DscResources/blob/master/StyleGuidelines.md) and the PowerShell verbs (https://learn.microsoft.com/en-us/powershell/scripting/developer/cmdlet/approved-verbs-for-windows-powershell-commands)
 
 ## Contributions
 


### PR DESCRIPTION
Updated Style Guidelines to new learn.microsoft.com source documentation.

Fixes # (broken reference link)

Changes proposed in this pull request:
 - replaced documentation link with functional one.

How to test this code:
 - review old link and new link. 

Has been tested on (remove any that don't apply):
 - Powershell 3 and above
 - Windows 7 and above
 - SQL Server 2012 and above
