### PR TITLE
Addresses #394, #409, adding SSRS 2022 vNext support to the SQLServer…

### DIFF
--- a/ReportingServicesTools/Libraries/library.ps1
+++ b/ReportingServicesTools/Libraries/library.ps1
@@ -112,9 +112,14 @@ namespace Microsoft.ReportingServicesTools
         SQLServer2017 = 14,
 
         /// <summary>
+        /// SQL Server 2019
+        /// </summary>
+        SQLServer2017 = 15,
+
+        /// <summary>
         /// SQL Server vNext
         /// </summary>
-        SQLServervNext = 15
+        SQLServervNext = 16
     }
 }
 "@

--- a/ReportingServicesTools/Libraries/library.ps1
+++ b/ReportingServicesTools/Libraries/library.ps1
@@ -117,9 +117,14 @@ namespace Microsoft.ReportingServicesTools
         SQLServer2019 = 15,
 
         /// <summary>
+        /// SQL Server 2022
+        /// </summary>
+        SQLServer2022 = 16,
+
+        /// <summary>
         /// SQL Server vNext
         /// </summary>
-        SQLServervNext = 16
+        SQLServervNext = 17
     }
 }
 "@

--- a/ReportingServicesTools/Libraries/library.ps1
+++ b/ReportingServicesTools/Libraries/library.ps1
@@ -114,7 +114,7 @@ namespace Microsoft.ReportingServicesTools
         /// <summary>
         /// SQL Server 2019
         /// </summary>
-        SQLServer2017 = 15,
+        SQLServer2019 = 15,
 
         /// <summary>
         /// SQL Server vNext

--- a/ReportingServicesTools/Libraries/library.ps1
+++ b/ReportingServicesTools/Libraries/library.ps1
@@ -119,12 +119,7 @@ namespace Microsoft.ReportingServicesTools
         /// <summary>
         /// SQL Server 2022
         /// </summary>
-        SQLServer2022 = 16,
-
-        /// <summary>
-        /// SQL Server vNext
-        /// </summary>
-        SQLServervNext = 17
+        SQLServer2022 = 16
     }
 }
 "@

--- a/Tests/Admin/Set-RsDatabase.Tests.ps1
+++ b/Tests/Admin/Set-RsDatabase.Tests.ps1
@@ -1,10 +1,10 @@
 function Get-DatabaseName() {
-    $wmiObject = New-RsConfigurationSettingObject -ReportServerInstance PBIRS -ReportServerVersion SQLServervNext
+    $wmiObject = New-RsConfigurationSettingObject -ReportServerInstance PBIRS -ReportServerVersion SQLServer2019
     return $wmiObject.DatabaseName
 }
 
 function Get-CredentialType() {
-    $wmiObject = New-RsConfigurationSettingObject -ReportServerInstance PBIRS -ReportServerVersion SQLServervNext
+    $wmiObject = New-RsConfigurationSettingObject -ReportServerInstance PBIRS -ReportServerVersion SQLServer2019
     switch ($wmiObject.DatabaseLogonType) {
         0 { return 'Windows' }
         1 { return 'SQL' }
@@ -26,7 +26,7 @@ Describe "Set-RsDatabase" {
         $databaseServerName = 'localhost'
         $databaseName = 'ReportServer' + [System.DateTime]::Now.Ticks
         $credentialType = 'ServiceAccount'
-        Set-RsDatabase -DatabaseServerName $databaseServerName -DatabaseName $databaseName -DatabaseCredentialType $credentialType -Confirm:$false -Verbose -ReportServerInstance PBIRS -ReportServerVersion SQLServervNext
+        Set-RsDatabase -DatabaseServerName $databaseServerName -DatabaseName $databaseName -DatabaseCredentialType $credentialType -Confirm:$false -Verbose -ReportServerInstance PBIRS -ReportServerVersion SQLServer2019
         
         It "Should update database and credentials" {
             Get-DatabaseName | Should be $databaseName
@@ -39,7 +39,7 @@ Describe "Set-RsDatabase" {
         $databaseName = 'ReportServer' + [System.DateTime]::Now.Ticks
         $credentialType = 'SQL'
         $credential = Get-SaCredentials
-        Set-RsDatabase -DatabaseServerName $databaseServerName -DatabaseName $databaseName -DatabaseCredentialType $credentialType -DatabaseCredential $credential -Confirm:$false -Verbose -ReportServerInstance PBIRS -ReportServerVersion SQLServervNext
+        Set-RsDatabase -DatabaseServerName $databaseServerName -DatabaseName $databaseName -DatabaseCredentialType $credentialType -DatabaseCredential $credential -Confirm:$false -Verbose -ReportServerInstance PBIRS -ReportServerVersion SQLServer2019
         
         It "Should update database and credentials" {
             Get-DatabaseName | Should be $databaseName
@@ -52,7 +52,7 @@ Describe "Set-RsDatabase" {
         $databaseName = 'ReportServer'
         $credentialType = 'SQL'
         $credential = Get-SaCredentials
-        Set-RsDatabase -DatabaseServerName $databaseServerName -DatabaseName $databaseName -DatabaseCredentialType $credentialType -DatabaseCredential $credential -IsExistingDatabase -Confirm:$false -Verbose -ReportServerInstance PBIRS -ReportServerVersion SQLServervNext
+        Set-RsDatabase -DatabaseServerName $databaseServerName -DatabaseName $databaseName -DatabaseCredentialType $credentialType -DatabaseCredential $credential -IsExistingDatabase -Confirm:$false -Verbose -ReportServerInstance PBIRS -ReportServerVersion SQLServer2019
         
         It "Should update database and credentials" {
             Get-DatabaseName | Should be $databaseName
@@ -64,7 +64,7 @@ Describe "Set-RsDatabase" {
         $databaseServerName = 'localhost'
         $databaseName = 'ReportServer'
         $credentialType = 'ServiceAccount'
-        Set-RsDatabase -DatabaseServerName $databaseServerName -DatabaseName $databaseName -DatabaseCredentialType $credentialType -IsExistingDatabase -Confirm:$false -Verbose -ReportServerInstance PBIRS -ReportServerVersion SQLServervNext
+        Set-RsDatabase -DatabaseServerName $databaseServerName -DatabaseName $databaseName -DatabaseCredentialType $credentialType -IsExistingDatabase -Confirm:$false -Verbose -ReportServerInstance PBIRS -ReportServerVersion SQLServer2019
         
         It "Should update database and credentials" {
             Get-DatabaseName | Should be $databaseName

--- a/Tests/Admin/Set-RsDatabaseCredentials.Tests.ps1
+++ b/Tests/Admin/Set-RsDatabaseCredentials.Tests.ps1
@@ -1,5 +1,5 @@
 function Get-CredentialType() {
-    $wmiObject = New-RsConfigurationSettingObject -ReportServerInstance PBIRS -ReportServerVersion SQLServervNext
+    $wmiObject = New-RsConfigurationSettingObject -ReportServerInstance PBIRS -ReportServerVersion SQLServer2019
     switch ($wmiObject.DatabaseLogonType) {
         0 { return 'Windows' }
         1 { return 'SQL' }
@@ -20,7 +20,7 @@ Describe "Set-RsDatabaseCredentials" {
     Context "Changing database credential type to ServiceAccount credentials" {
         $credentialType = 'SQL'
         $credential = Get-SaCredentials
-        Set-RsDatabaseCredentials -DatabaseCredentialType $credentialType -DatabaseCredential $credential -Confirm:$false -Verbose -ReportServerInstance PBIRS -ReportServerVersion SQLServervNext
+        Set-RsDatabaseCredentials -DatabaseCredentialType $credentialType -DatabaseCredential $credential -Confirm:$false -Verbose -ReportServerInstance PBIRS -ReportServerVersion SQLServer2019
         
         It "Should update credentials" {
             Get-CredentialType | Should be $credentialType
@@ -29,7 +29,7 @@ Describe "Set-RsDatabaseCredentials" {
 
     Context "Changing database credential type to SQL credentials" {
         $credentialType = 'ServiceAccount'
-        Set-RsDatabaseCredentials -DatabaseCredentialType $credentialType -Confirm:$false -Verbose -ReportServerInstance PBIRS -ReportServerVersion SQLServervNext
+        Set-RsDatabaseCredentials -DatabaseCredentialType $credentialType -Confirm:$false -Verbose -ReportServerInstance PBIRS -ReportServerVersion SQLServer2019
         
         It "Should update credentials" {
             Get-CredentialType | Should be $credentialType

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -67,9 +67,9 @@ before_test:
 
     Import-Module .\ReportingServicesTools\ReportingServicesTools.psd1 
     Write-Host "Configuring PBI RS" (Get-Date).DateTime
-    Set-RsDatabase -ReportServerInstance PBIRS -ReportServerVersion SQLServervNext -DatabaseServerName localhost -DatabaseName ReportServer -DatabaseCredentialType ServiceAccount -Confirm:$false
-    Set-PbiRsUrlReservation -ReportServerInstance PBIRS -ReportServerVersion SQLServervNext
-    try {Initialize-Rs -ReportServerInstance PBIRS -ReportServerVersion SQLServervNext} catch {}
+    Set-RsDatabase -ReportServerInstance PBIRS -ReportServerVersion SQLServer2019 -DatabaseServerName localhost -DatabaseName ReportServer -DatabaseCredentialType ServiceAccount -Confirm:$false
+    Set-PbiRsUrlReservation -ReportServerInstance PBIRS -ReportServerVersion SQLServer2019
+    try {Initialize-Rs -ReportServerInstance PBIRS -ReportServerVersion SQLServer2019} catch {}
     Stop-Service PowerBIReportServer
     Start-Service PowerBIReportServer
     Start-Service SQLSERVERAGENT


### PR DESCRIPTION
…Version enum

Fixes #394 #409 .

Changes proposed in this pull request:
 - Adds SSRS 2022 as vNext in SQLServerVersion enum to allow operations on SSRS 2022

How to test this code:
 - Try using "16" as SQL server version in various commands

Has been tested on (remove any that don't apply):
 - Powershell 3 and above
 - Windows 7 and above
 - SQL Server 2012 and above
