### PR TITLE
Update library.ps1: Use Write-Warning instead of Write-Error for catch block

### DIFF
--- a/ReportingServicesTools/Libraries/library.ps1
+++ b/ReportingServicesTools/Libraries/library.ps1
@@ -130,4 +130,4 @@ namespace Microsoft.ReportingServicesTools
 "@
 
 Try { Add-Type -TypeDefinition $source -ErrorAction Stop }
-catch { Write-Warning "Error: $_" }
+catch { Write-Warning "$_" }

--- a/ReportingServicesTools/Libraries/library.ps1
+++ b/ReportingServicesTools/Libraries/library.ps1
@@ -130,4 +130,4 @@ namespace Microsoft.ReportingServicesTools
 "@
 
 Try { Add-Type -TypeDefinition $source -ErrorAction Stop }
-catch { Write-Error "Error: $_" }
+catch { Write-Warning "Error: $_" }


### PR DESCRIPTION
fix https://github.com/microsoft/ReportingServicesTools/issues/435#issuecomment-2697265750.

Importing ReportingServicesTools Module...
C:\Users\Akash\Documents\WindowsPowerShell\Modules\ReportingServicesTools\ReportingServicesTools\Libraries\library.ps
1 : Error: Cannot add type. The type name 'Microsoft.ReportingServicesTools.ConnectionHost' already exists.
At C:\Users\Akash\Documents\WindowsPowerShell\Modules\ReportingServicesTools\ReportingServicesTools\ReportingServices
Tools.psm1:1 char:1

Remove-Module can't fully unload a module, so when re-importing the module, it threw the error "the type already exists", using warning instead of error to unblock install.ps1