### PR TITLE
Adding option to se SMTP Use SSL to False, default is True

### DIFF
--- a/ReportingServicesTools/Functions/Admin/Set-RsEmailSettings.ps1
+++ b/ReportingServicesTools/Functions/Admin/Set-RsEmailSettings.ps1
@@ -20,6 +20,9 @@ function Set-RsEmailSettings
         .PARAMETER SmtpServer
             Specify the SMTP Server address.
         
+        .PARAMETER SMTPUseSSL
+            Specify the the use of SSL.
+        
         .PARAMETER SenderAddress
             Specify sender email address for the email.
         
@@ -85,6 +88,10 @@ function Set-RsEmailSettings
         [string]
         $SmtpServer,
         
+        [Parameter(Mandatory = $False)]
+        [bool]
+        $SMTPUseSSL = $true,
+
         [Parameter(Mandatory = $True)]
         [string]
         $SenderAddress,
@@ -148,7 +155,7 @@ function Set-RsEmailSettings
     
     try
     {
-        $result = $rsWmiObject.SetAuthenticatedEmailConfiguration($true, $SmtpServer, $SenderAddress, $UserName, $Password, $Authentication.Value__, $true)
+        $result = $rsWmiObject.SetAuthenticatedEmailConfiguration($true, $SmtpServer, $SenderAddress, $UserName, $Password, $Authentication.Value__, $SMTPUseSSL)
     }
     catch
     {


### PR DESCRIPTION
Fixes # Current code doesn't allow to set SMTP Use SSL to False, only the default True

Changes proposed in this pull request:
 - Allow the option to set SMTP Use SSL to False, the default remains True
 - 
 - 

How to test this code:
 - Set-RsEmailSettings -Authentication None  -SmtpServer "smtp.server" -SMTPUseSSL $false -SenderAddress "SSRS@mail.server.com" 
 - 
 - 

Has been tested on (remove any that don't apply):
 - Powershell 3 and above
 - Windows 7 and above
 - SQL Server 2012 and above
